### PR TITLE
Ability to add pauses and send delayed DTMF tones

### DIFF
--- a/src/qml/DialerPage/DialerPage.qml
+++ b/src/qml/DialerPage/DialerPage.qml
@@ -443,6 +443,14 @@ Page {
                     // replace 0 by +
                     input.remove(input.cursorPosition - 1, input.cursorPosition)
                     input.insert(input.cursorPosition, "+")
+                } else if (dialNumber.length > 1 && keycode == Qt.Key_ssharp) {
+                    // replace '#' by ';'. don't do this if this itself is the first character
+                    input.remove(input.cursorPosition - 1, input.cursorPosition)
+                    input.insert(input.cursorPosition, ";")
+                } else if (dialNumber.length > 1 && keycode == Qt.Key_Asterisk) {
+                    // replace '*' by ','. don't do this if this itself is the first character
+                    input.remove(input.cursorPosition - 1, input.cursorPosition)
+                    input.insert(input.cursorPosition, ",")
                 }
             }
         }

--- a/src/qml/LiveCallPage/LiveCall.qml
+++ b/src/qml/LiveCallPage/LiveCall.qml
@@ -47,7 +47,6 @@ Page {
     property int defaultTimeout: 10000
     property string initialStatus: ""
     property string initialNumber: ""
-    property string delayedDialNumber: ""
     property string caller: {
         if (call && call.isConference) {
             return i18n.tr("Conference");
@@ -134,9 +133,8 @@ Page {
                 statusLabel.text = "";
                 liveCall.call = Qt.binding(function() { return callManager.foregroundCall; });
 
-                console.log("delayedDialNumber = " + delayedDialNumber);
-                if (delayedDialNumber != "") {
-                    console.log("Arm delayed dial timer for text=" + delayedDialNumber);
+                if (mainView.delayedDialNumber != "") {
+                    console.log("Arm delayed dial timer for text=" + mainView.delayedDialNumber);
                     delayedDial.interval = 1;
                     delayedDial.running = true;
                 }
@@ -153,7 +151,7 @@ Page {
         id: callConnection
         target: call
         onCallEnded: {
-            delayedDialNumber = "";
+            mainView.delayedDialNumber = "";
             delayedDial.running = false;
 
             var callObject = {};
@@ -357,26 +355,26 @@ Page {
         running: false
 
         onTriggered: {
-            if (delayedDialNumber.length == 0) {
+            if (mainView.delayedDialNumber.length == 0) {
                 // not re-arming the timer
                 return;
             }
 
-            if (delayedDialNumber[0] == ";") {
+            if (mainView.delayedDialNumber[0] == ";") {
                 interval = 1000;
                 console.log("wait for 1 second");
-            } else if (delayedDialNumber[0] == ",") {
+            } else if (mainView.delayedDialNumber[0] == ",") {
                 interval = 2000;
                 console.log("wait for 2 second");
             } else {
                 interval = 250;
-                console.log("dial " + delayedDialNumber[0]);
-                dtmfEntry += delayedDialNumber[0];
-                call.sendDTMF(delayedDialNumber[0]);
+                console.log("dial " + mainView.delayedDialNumber[0]);
+                dtmfEntry += mainView.delayedDialNumber[0];
+                call.sendDTMF(mainView.delayedDialNumber[0]);
             }
 
-            delayedDialNumber = delayedDialNumber.substring(1);
-            running = delayedDialNumber.length > 0;
+            mainView.delayedDialNumber = mainView.delayedDialNumber.substring(1);
+            running = mainView.delayedDialNumber.length > 0;
         }
     }
 

--- a/src/qml/dialer-app.qml
+++ b/src/qml/dialer-app.qml
@@ -95,7 +95,8 @@ MainView {
             }
 
             if (pendingNumberToDial != "") {
-                callManager.startCall(pendingNumberToDial, mainView.account.accountId);
+                var dialPrefix = setDelayedDialNumberAndReturnPrefix(pendingNumberToDial);
+                callManager.startCall(dialPrefix, mainView.account.accountId);
             }
             pendingNumberToDial = "";
         }
@@ -333,6 +334,17 @@ MainView {
         callManager.startCall(number, account.accountId);
     }
 
+    function setDelayedDialNumberAndReturnPrefix(number) {
+        // If the number contains ';' or ',', we want to dial
+        // the leading number first, and key in everything later
+        // with delays
+        var semiIdx = number.indexOf(";"); semiIdx = (semiIdx == -1) ? number.length : semiIdx;
+        var commaIdx = number.indexOf(","); commaIdx = (commaIdx == -1) ? number.length : commaIdx;
+        var minDelayIdx = Math.min(semiIdx, commaIdx);
+        delayedDialNumber = number.substring(minDelayIdx);
+        return number.substring(0, minDelayIdx);
+    }
+
     function call(number, skipDefaultSimDialog) {
         // clear the values here so that the changed signals are fired when the new value is set
         pendingNumberToDial = "";
@@ -391,15 +403,7 @@ MainView {
             return
         }
 
-        // If the number contains ';' or ',', we want to dial
-        // the leading number first, and key in everything later
-        // with delays
-        var semiIdx = number.indexOf(";"); semiIdx = (semiIdx == -1) ? number.length : semiIdx;
-        var commaIdx = number.indexOf(","); commaIdx = (commaIdx == -1) ? number.length : commaIdx;
-        var minDelayIdx = Math.min(semiIdx, commaIdx);
-        delayedDialNumber = number.substring(minDelayIdx);
-        var dialPrefix = number.substring(0, minDelayIdx);
-        console.log("dial prefix=" + dialPrefix + " delayed dial=" + delayedDialNumber);
+        var dialPrefix = setDelayedDialNumberAndReturnPrefix(number);
 
         animateLiveCall();
 
@@ -477,8 +481,6 @@ MainView {
         var properties = {}
         properties["initialStatus"] = initialStatus
         properties["initialNumber"] = initialNumber
-        properties["delayedDialNumber"] = delayedDialNumber
-        console.log("switchToLiveCall: delayed dial=" + delayedDialNumber)
         if (isEmergencyNumber(pendingNumberToDial)) {
             properties["defaultTimeout"] = 30000
         }


### PR DESCRIPTION
closes #44 
This is the first set of changes I am ever making with qml so may not be the best way to do this. Appreciate any input/feedback. I wasn't able to get the autopilot tests running (hitting http://ci.ubuntu.com/smokeng/utopic/touch/mako/260:20140928:20140923.1/10727/dialer_app/1748114/) which is why I haven't added any test cases as well.

- [DialerPage.qml] Holding 'sharp' replaces it with a ';' -> 1 second delay (note can't be the first digit in the number to dial)
- [DialerPage.qml] Holding '*' replaces it with a ',' -> 2 second delay (again, can't be the first digit in the number to dial)
- [LiveCall.qml] When call connects, start a new timer "delayedDial" which does delays or sends DTMF tones for everything in "delayedDialNumber" property
- [dialer-app.qml] When we start a call, instead of using the full number with commas and semi-colons, send the initial prefix and set the rest to delayedDialNumber