### PR TITLE
Change defaults in Contacts for Faster Use

### DIFF
--- a/src/qml/ContactsPage/ContactsPage.qml
+++ b/src/qml/ContactsPage/ContactsPage.qml
@@ -92,14 +92,15 @@ Page {
                 leftMargin: units.gu(2)
                 bottom: parent ? parent.bottom : undefined
             }
-            model:  [i18n.ctr("All Contacts", "All"), i18n.tr("Favorites")]
+
+            model:  [i18n.tr("Favorites"),i18n.ctr("All Contacts","All")]
             onSelectedIndexChanged: {
                 switch (selectedIndex) {
                 case 0:
-                    contactList.showAllContacts()
+                    contactList.showFavoritesContacts()
                     break;
                 case 1:
-                    contactList.showFavoritesContacts()
+                    contactList.showAllContacts()
                     break;
                 default:
                     break;
@@ -147,13 +148,14 @@ Page {
                         contactList.forceActiveFocus()
                         contactsPage.state = "default"
                         contactsPage.head.sections.selectedIndex = 0
+                        showNotification("Title","message6")
                     }
                 }
             ]
 
             PropertyChanges {
                 target: pageHeader
-                leadingActions: searchingState.leadingActions
+                trailingActions: searchingState.trailingActions
                 contents: searchField
                 extension: null
             }
@@ -216,7 +218,8 @@ Page {
             contactList.listModel.importContacts("file://" + QTCONTACTS_PRELOAD_VCARD)
         }
 	// focus the search field / show the keyboard on start
-        state = "searching";
+        //state = "searching";
+        contactList.showFavoritesContacts()
     }
 
     onActiveChanged: {


### PR DESCRIPTION
For faster use of the phone, changed the defaults in dialer - contacts from the previous "search" option to just displaying favorites first. This is the more logical organization since most of us dial the same people most of the time. Looking for a new person to dial is more of an exception.

Changed the defaults also to show Favorites first on the List view instead of All Contacts first.

This eliminates a lot of clicks when making calls to a favorite list.