### PR TITLE
Make sublabels smaller on pad buttons

### DIFF
--- a/setup/gui/dialer-app.desktop
+++ b/setup/gui/dialer-app.desktop
@@ -236,7 +236,6 @@ Terminal=false
 Icon=${SNAP}/usr/share/dialer-app/assets/dialer-app.png
 MimeType=x-scheme-handler/contact;x-scheme-handler/call
 X-Ubuntu-Touch=true
-X-Ubuntu-Supported-Orientations=portrait
 X-Ubuntu-StageHint=SideStage
 X-Ubuntu-Single-Instance=true
 X-Ubuntu-Default-Department-ID=accessories

--- a/src/dialer-app.desktop.in.in
+++ b/src/dialer-app.desktop.in.in
@@ -9,7 +9,6 @@ Terminal=false
 Icon=@CMAKE_INSTALL_PREFIX@/@DIALER_APP_DIR@/assets/dialer-app.svg
 MimeType=x-scheme-handler/contact;x-scheme-handler/call
 X-Ubuntu-Touch=true
-X-Ubuntu-Supported-Orientations=portrait
 X-Ubuntu-StageHint=SideStage
 X-Ubuntu-Single-Instance=true
 X-Ubuntu-Default-Department-ID=accessories

--- a/src/qml/DialerPage/Keypad.qml
+++ b/src/qml/DialerPage/Keypad.qml
@@ -26,7 +26,7 @@ Item {
 
     readonly property int keysWidth: Math.min(units.gu(11), (keypad.width  / (keys.columns + 1)))
     readonly property int keysHeight: Math.min(units.gu(8), (keypad.height / (keys.rows + 1)))
-    property double labelPixelSize: units.dp(30)
+    property double labelPixelSize: keypad.height > units.dp(160) ? units.dp(30) : units.dp(20)
     property bool showVoicemail: false
     property alias spacing: keys.columnSpacing
 
@@ -40,9 +40,6 @@ Item {
         columns: 3
         rowSpacing: columnSpacing
         anchors.fill: parent
-        //horizontalItemAlignment: Grid.AlignHCenter
-        //verticalItemAlignment: Grid.AlignVCenter
-
 
         KeypadButton {
             objectName: "buttonOne"

--- a/src/qml/DialerPage/KeypadButton.qml
+++ b/src/qml/DialerPage/KeypadButton.qml
@@ -60,7 +60,7 @@ MouseArea {
             anchors {
                 horizontalCenter: parent.horizontalCenter
                 verticalCenter: parent.verticalCenter
-                verticalCenterOffset: -units.gu(0.5)
+                verticalCenterOffset: parent.height > units.gu(3.5) ? -units.gu(0.5) : 0
             }
 
             font.pixelSize: units.dp(30)
@@ -78,11 +78,26 @@ MouseArea {
 
             fontSize: "x-small"
             color: theme.palette.normal.backgroundSecondaryText
+            visible: parent.height > units.gu(5)
+        }
+
+        Label {
+            id: verticalSublabelItem
+
+            anchors {
+                right: parent.right
+                verticalCenter: labelItem.verticalCenter
+            }
+
+            text: sublabelItem.text.split("").join("\n")
+            fontSize: parent.height > units.gu(3.5) ? "x-small" : "xx-small"
+            color: theme.palette.normal.backgroundSecondaryText
+            visible: !sublabelItem.visible && parent.height > units.gu(2.5)
         }
 
         Icon {
             id: subImage
-            visible: name != ""
+            visible: name != "" && parent.height > units.gu(5)
             anchors {
                 top: labelItem.bottom
                 horizontalCenter: labelItem.horizontalCenter


### PR DESCRIPTION
Make key button on dialer pad smaller for small screens or hide them (very small screens)

Fixes #136 and #6 

Needs to be tested on real device first