### PR TITLE
Make keypad to adapt to horizontal view

### DIFF
--- a/setup/gui/dialer-app.desktop
+++ b/setup/gui/dialer-app.desktop
@@ -242,4 +242,3 @@ X-Ubuntu-Single-Instance=true
 X-Ubuntu-Default-Department-ID=accessories
 X-Ubuntu-Splash-Show-Header=true
 X-Screenshot=/snap/dialer-app/current/usr/share/dialer-app/assets/dialer-app-screenshot.png
-X-Ubuntu-Supported-Orientations=portrait

--- a/src/dialer-app.desktop.in.in
+++ b/src/dialer-app.desktop.in.in
@@ -9,7 +9,6 @@ Terminal=false
 Icon=@CMAKE_INSTALL_PREFIX@/@DIALER_APP_DIR@/assets/dialer-app.svg
 MimeType=x-scheme-handler/contact;x-scheme-handler/call
 X-Ubuntu-Touch=true
-X-Ubuntu-Supported-Orientations=portrait
 X-Ubuntu-StageHint=SideStage
 X-Ubuntu-Single-Instance=true
 X-Ubuntu-Default-Department-ID=accessories

--- a/src/qml/DialerPage/Keypad.qml
+++ b/src/qml/DialerPage/Keypad.qml
@@ -26,7 +26,7 @@ Item {
 
     readonly property int keysWidth: Math.min(units.gu(11), (keypad.width  / (keys.columns + 1)))
     readonly property int keysHeight: Math.min(units.gu(8), (keypad.height / (keys.rows + 1)))
-    property double labelPixelSize: units.dp(30)
+    property double labelPixelSize: keypad.height > units.dp(160) ? units.dp(30) : units.dp(20)
     property bool showVoicemail: false
     property alias spacing: keys.columnSpacing
 
@@ -40,9 +40,6 @@ Item {
         columns: 3
         rowSpacing: columnSpacing
         anchors.fill: parent
-        //horizontalItemAlignment: Grid.AlignHCenter
-        //verticalItemAlignment: Grid.AlignVCenter
-
 
         KeypadButton {
             objectName: "buttonOne"

--- a/src/qml/DialerPage/KeypadButton.qml
+++ b/src/qml/DialerPage/KeypadButton.qml
@@ -30,6 +30,7 @@ MouseArea {
     property int keycode
     property bool isCorner: false
     property int corner
+    property bool isVertical: parent.height > parent.width
 
     UbuntuShape {
         objectName: "keypadButtonUbuntuShape"
@@ -42,6 +43,47 @@ MouseArea {
             }
         }
     }
+
+    states: [
+        State {
+            name: "VERTICAL"
+            when: isVertical
+            AnchorChanges {
+                target: labelItem
+                anchors.horizontalCenter: parent.horizontalCenter
+            }
+            AnchorChanges {
+                target: sublabelItem
+                anchors.horizontalCenter: labelItem.horizontalCenter
+                anchors.top: labelItem.bottom
+            }
+            AnchorChanges {
+                target: subImage
+                anchors.horizontalCenter: labelItem.horizontalCenter
+                anchors.top: labelItem.bottom
+            }
+        },
+
+        State {
+            name: "HORIZONTAL"
+            when: !isVertical
+            AnchorChanges {
+                target: labelItem
+                anchors.horizontalCenter: undefined
+                anchors.left: parent.left
+            }
+            AnchorChanges {
+                target: sublabelItem
+                anchors.left: labelItem.right
+                anchors.verticalCenter: parent.verticalCenter
+            }
+            AnchorChanges {
+                target: subImage
+                anchors.left: labelItem.right
+                anchors.verticalCenter: parent.verticalCenter
+            }
+        }
+    ]
 
     Item {
         objectName: "keypadButtonLabelsContainer"
@@ -58,9 +100,9 @@ MouseArea {
             id: labelItem
 
             anchors {
-                horizontalCenter: parent.horizontalCenter
                 verticalCenter: parent.verticalCenter
-                verticalCenterOffset: -units.gu(0.5)
+                verticalCenterOffset: button.state == "VERTICAL" ? -units.gu(0.5) : 0
+                leftMargin: button.state == "VERTICAL" ? undefined : units.gu(0.5)
             }
 
             font.pixelSize: units.dp(30)
@@ -71,9 +113,8 @@ MouseArea {
             id: sublabelItem
 
             anchors {
-                top: labelItem.bottom
-                topMargin: units.dp(1.5)
-                horizontalCenter: labelItem.horizontalCenter
+                topMargin: button.state == "VERTICAL" ? units.dp(1.5) : undefined
+                leftMargin: button.state == "VERTICAL" ? undefined : units.gu(0.5)
             }
 
             fontSize: "x-small"
@@ -83,11 +124,12 @@ MouseArea {
         Icon {
             id: subImage
             visible: name != ""
+
             anchors {
-                top: labelItem.bottom
-                horizontalCenter: labelItem.horizontalCenter
-                topMargin: units.dp(1.5)
+                topMargin: button.state == "VERTICAL" ? units.dp(1.5) : undefined
+                leftMargin: button.state == "VERTICAL" ? undefined : units.gu(0.5)
             }
+
             opacity: 0.8
             width: units.gu(2)
             height: units.gu(2)

--- a/src/qml/DialerPage/KeypadButton.qml
+++ b/src/qml/DialerPage/KeypadButton.qml
@@ -30,7 +30,7 @@ MouseArea {
     property int keycode
     property bool isCorner: false
     property int corner
-    property bool isVertical: parent.height > parent.width
+    property bool isVertical: parent.height > (parent.width * .75)
 
     UbuntuShape {
         objectName: "keypadButtonUbuntuShape"


### PR DESCRIPTION
Make key button on dialer pad smaller for small screens and in horizontal design for horizontal view

Fixes #136 and #6

Needs to be tested on E4.5 with two SIMs

On Arale:

![screenshot20201108_032932967](https://user-images.githubusercontent.com/6640041/98455668-fc226400-2173-11eb-8ae9-2f5fe448c4dd.png)
![screenshot20201108_032930025](https://user-images.githubusercontent.com/6640041/98455666-fb89cd80-2173-11eb-8ee2-ddd060f46fef.png)

