### PR TITLE
Contact search via dial pad

### DIFF
--- a/po/CMakeLists.txt
+++ b/po/CMakeLists.txt
@@ -30,7 +30,7 @@ endforeach(PO_FILE)
 
 find_program(XGETTEXT_EXECUTABLE xgettext)
 if(XGETTEXT_EXECUTABLE)
-    add_custom_target(${POT_FILE}
+    add_custom_target(${POT_FILE} ALL
               COMMENT "Generating translation template"
               COMMAND ${INTLTOOL_EXTRACT} --update --type=gettext/ini
                       --srcdir=${CMAKE_CURRENT_SOURCE_DIR} ${DESKTOP_FILE_IN_IN}

--- a/po/dialer-app.pot
+++ b/po/dialer-app.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-10-15 11:29+0000\n"
+"POT-Creation-Date: 2021-03-31 14:12+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: ../src/qml/DialerPage/Keypad.qml:242
+#: ../src/qml/DialerPage/Keypad.qml:250
 msgid "#"
 msgstr ""
 
@@ -73,56 +73,56 @@ msgstr[1] ""
 msgid "(%1)"
 msgstr ""
 
-#: ../src/qml/DialerPage/Keypad.qml:206
+#: ../src/qml/DialerPage/Keypad.qml:214
 msgid "*"
 msgstr ""
 
 #: ../src/qml/DialerPage/DialerBottomEdge.qml:26
-#: ../src/qml/DialerPage/Keypad.qml:223
+#: ../src/qml/DialerPage/Keypad.qml:231
 msgid "+"
 msgstr ""
 
-#: ../src/qml/DialerPage/Keypad.qml:222
+#: ../src/qml/DialerPage/Keypad.qml:230
 msgid "0"
 msgstr ""
 
-#: ../src/qml/DialerPage/Keypad.qml:51
+#: ../src/qml/DialerPage/Keypad.qml:59
 msgid "1"
 msgstr ""
 
-#: ../src/qml/DialerPage/Keypad.qml:68
+#: ../src/qml/DialerPage/Keypad.qml:76
 msgid "2"
 msgstr ""
 
-#: ../src/qml/DialerPage/Keypad.qml:85
+#: ../src/qml/DialerPage/Keypad.qml:93
 msgid "3"
 msgstr ""
 
-#: ../src/qml/DialerPage/Keypad.qml:102
+#: ../src/qml/DialerPage/Keypad.qml:110
 msgid "4"
 msgstr ""
 
-#: ../src/qml/DialerPage/Keypad.qml:119
+#: ../src/qml/DialerPage/Keypad.qml:127
 msgid "5"
 msgstr ""
 
-#: ../src/qml/DialerPage/Keypad.qml:136
+#: ../src/qml/DialerPage/Keypad.qml:144
 msgid "6"
 msgstr ""
 
-#: ../src/qml/DialerPage/Keypad.qml:153
+#: ../src/qml/DialerPage/Keypad.qml:161
 msgid "7"
 msgstr ""
 
-#: ../src/qml/DialerPage/Keypad.qml:170
+#: ../src/qml/DialerPage/Keypad.qml:178
 msgid "8"
 msgstr ""
 
-#: ../src/qml/DialerPage/Keypad.qml:187
+#: ../src/qml/DialerPage/Keypad.qml:195
 msgid "9"
 msgstr ""
 
-#: ../src/qml/DialerPage/Keypad.qml:69
+#: ../src/qml/DialerPage/Keypad.qml:77
 msgid "ABC"
 msgstr ""
 
@@ -130,7 +130,7 @@ msgstr ""
 msgid "Active"
 msgstr ""
 
-#: ../src/qml/SettingsPage/SettingsPage.qml:122
+#: ../src/qml/SettingsPage/SettingsPage.qml:123
 msgid "Add an online account"
 msgstr ""
 
@@ -157,15 +157,15 @@ msgstr ""
 msgid "Call"
 msgstr ""
 
-#: ../src/qml/dialer-app.qml:617
+#: ../src/qml/dialer-app.qml:618
 msgid "Call Barring"
 msgstr ""
 
-#: ../src/qml/dialer-app.qml:628
+#: ../src/qml/dialer-app.qml:629
 msgid "Call Forwarding"
 msgstr ""
 
-#: ../src/qml/dialer-app.qml:639
+#: ../src/qml/dialer-app.qml:640
 msgid "Call Waiting"
 msgstr ""
 
@@ -204,18 +204,18 @@ msgstr ""
 msgid "Call waiting"
 msgstr ""
 
-#: ../src/qml/DialerPage/DialerPage.qml:556
+#: ../src/qml/DialerPage/DialerPage.qml:605
 #: ../src/qml/LiveCallPage/ConferenceCallDisplay.qml:113
 #: ../src/qml/LiveCallPage/LiveCall.qml:513
 #: ../src/qml/LiveCallPage/MultiCallDisplay.qml:108
 msgid "Calling"
 msgstr ""
 
-#: ../src/qml/dialer-app.qml:650
+#: ../src/qml/dialer-app.qml:651
 msgid "Calling Line Presentation"
 msgstr ""
 
-#: ../src/qml/dialer-app.qml:662
+#: ../src/qml/dialer-app.qml:663
 msgid "Calling Line Restriction"
 msgstr ""
 
@@ -256,11 +256,11 @@ msgstr ""
 msgid "Conference call failure"
 msgstr ""
 
-#: ../src/qml/dialer-app.qml:656
+#: ../src/qml/dialer-app.qml:657
 msgid "Connected Line Presentation"
 msgstr ""
 
-#: ../src/qml/dialer-app.qml:668
+#: ../src/qml/dialer-app.qml:669
 msgid "Connected Line Restriction"
 msgstr ""
 
@@ -271,6 +271,10 @@ msgstr ""
 
 #: ../src/qml/SettingsPage/CallForwarding.qml:299
 msgid "Contact not associated with any phone number."
+msgstr ""
+
+#: ../src/qml/SettingsPage/SettingsPage.qml:136
+msgid "Contact search with dial pad (Experimental)"
 msgstr ""
 
 #: ../src/qml/ContactsPage/ContactsPage.qml:98
@@ -286,7 +290,7 @@ msgstr ""
 msgid "Could not forward to this contact"
 msgstr ""
 
-#: ../src/qml/DialerPage/Keypad.qml:86
+#: ../src/qml/DialerPage/Keypad.qml:94
 msgid "DEF"
 msgstr ""
 
@@ -299,7 +303,7 @@ msgid "Default country code"
 msgstr ""
 
 #: ../src/qml/HistoryPage/HistoryDetailsPage.qml:91
-#: ../src/qml/HistoryPage/HistoryDetailsPage.qml:258
+#: ../src/qml/HistoryPage/HistoryDetailsPage.qml:263
 #: ../src/qml/HistoryPage/HistoryPage.qml:350
 msgid "Delete"
 msgstr ""
@@ -339,7 +343,7 @@ msgstr ""
 msgid "Emergency Calls"
 msgstr ""
 
-#: ../src/qml/DialerPage/DialerPage.qml:514
+#: ../src/qml/DialerPage/DialerPage.qml:563
 msgid "Emergency call"
 msgstr ""
 
@@ -347,7 +351,7 @@ msgstr ""
 msgid "Enter a country code"
 msgstr ""
 
-#: ../src/qml/DialerPage/DialerPage.qml:332
+#: ../src/qml/DialerPage/DialerPage.qml:331
 #: ../src/qml/SettingsPage/CallForwardItem.qml:171
 msgid "Enter a number"
 msgstr ""
@@ -407,7 +411,7 @@ msgstr ""
 msgid "Forward to"
 msgstr ""
 
-#: ../src/qml/DialerPage/Keypad.qml:103
+#: ../src/qml/DialerPage/Keypad.qml:111
 msgid "GHI"
 msgstr ""
 
@@ -428,7 +432,7 @@ msgid "IMEI"
 msgstr ""
 
 #: ../src/qml/HistoryPage/HistoryDelegate.qml:65
-#: ../src/qml/HistoryPage/HistoryDetailsPage.qml:335
+#: ../src/qml/HistoryPage/HistoryDetailsPage.qml:340
 #: ../src/qml/HistoryPage/SwipeItemDemo.qml:189
 msgid "Incoming"
 msgstr ""
@@ -441,7 +445,7 @@ msgstr ""
 msgid "Invalid USSD code"
 msgstr ""
 
-#: ../src/qml/DialerPage/Keypad.qml:120
+#: ../src/qml/DialerPage/Keypad.qml:128
 msgid "JKL"
 msgstr ""
 
@@ -460,7 +464,7 @@ msgid ""
 "between them"
 msgstr ""
 
-#: ../src/qml/DialerPage/Keypad.qml:137
+#: ../src/qml/DialerPage/Keypad.qml:145
 msgid "MNO"
 msgstr ""
 
@@ -469,7 +473,7 @@ msgid "Merge calls"
 msgstr ""
 
 #: ../src/qml/HistoryPage/HistoryDelegate.qml:63
-#: ../src/qml/HistoryPage/HistoryDetailsPage.qml:333
+#: ../src/qml/HistoryPage/HistoryDetailsPage.qml:338
 #: ../src/qml/HistoryPage/HistoryPage.qml:68
 msgid "Missed"
 msgstr ""
@@ -486,7 +490,7 @@ msgstr ""
 msgid "No"
 msgstr ""
 
-#: ../src/qml/dialer-app.qml:383
+#: ../src/qml/dialer-app.qml:386
 msgid "No SIM card selected"
 msgstr ""
 
@@ -494,8 +498,8 @@ msgstr ""
 msgid "No calls"
 msgstr ""
 
-#: ../src/qml/DialerPage/DialerPage.qml:166 ../src/qml/dialer-app.qml:402
-#: ../src/qml/dialer-app.qml:407
+#: ../src/qml/DialerPage/DialerPage.qml:166 ../src/qml/dialer-app.qml:405
+#: ../src/qml/dialer-app.qml:410
 msgid "No network"
 msgstr ""
 
@@ -534,11 +538,11 @@ msgid "On hold"
 msgstr ""
 
 #: ../src/qml/HistoryPage/HistoryDelegate.qml:67
-#: ../src/qml/HistoryPage/HistoryDetailsPage.qml:337
+#: ../src/qml/HistoryPage/HistoryDetailsPage.qml:342
 msgid "Outgoing"
 msgstr ""
 
-#: ../src/qml/DialerPage/Keypad.qml:154
+#: ../src/qml/DialerPage/Keypad.qml:162
 msgid "PQRS"
 msgstr ""
 
@@ -595,7 +599,7 @@ msgstr ""
 msgid "Private number"
 msgstr ""
 
-#: ../src/qml/DialerPage/DialerPage.qml:569
+#: ../src/qml/DialerPage/DialerPage.qml:618
 #: ../src/qml/HistoryPage/HistoryPage.qml:47
 msgid "Recent"
 msgstr ""
@@ -685,20 +689,20 @@ msgstr ""
 msgid "Switch to default SIM:"
 msgstr ""
 
-#: ../src/qml/DialerPage/Keypad.qml:171
+#: ../src/qml/DialerPage/Keypad.qml:179
 msgid "TUV"
 msgstr ""
 
-#: ../src/qml/dialer-app.qml:408
+#: ../src/qml/dialer-app.qml:411
 #, qt-format
 msgid "There is currently no network on %1"
 msgstr ""
 
-#: ../src/qml/dialer-app.qml:402 ../src/qml/dialer-app.qml:409
+#: ../src/qml/dialer-app.qml:405 ../src/qml/dialer-app.qml:412
 msgid "There is currently no network."
 msgstr ""
 
-#: ../src/qml/DialerPage/DialerPage.qml:514
+#: ../src/qml/DialerPage/DialerPage.qml:563
 msgid "This is not an emergency number."
 msgstr ""
 
@@ -725,7 +729,7 @@ msgstr ""
 msgid "Voicemail"
 msgstr ""
 
-#: ../src/qml/DialerPage/Keypad.qml:188
+#: ../src/qml/DialerPage/Keypad.qml:196
 msgid "WXYZ"
 msgstr ""
 
@@ -738,7 +742,7 @@ msgstr ""
 msgid "You have to disable flight mode in order to make calls"
 msgstr ""
 
-#: ../src/qml/dialer-app.qml:383
+#: ../src/qml/dialer-app.qml:386
 msgid "You need to select a SIM card"
 msgstr ""
 

--- a/src/qml/DialerPage/ContactDialPadSearch.qml
+++ b/src/qml/DialerPage/ContactDialPadSearch.qml
@@ -26,7 +26,6 @@ Item {
     id:root
     objectName: "root"
     state: "NO_FILTER"
-    onStateChanged: console.log(state)
 
     property var searchHistory : []
     property  string phoneNumberField: ""
@@ -78,7 +77,6 @@ Item {
     }
 
     function push(pattern) {
-        console.log('pattern:', pattern)
         if (pattern && pattern.length > 0) {
             searchHistory.push(pattern)
 
@@ -110,7 +108,6 @@ Item {
         id:searchTimer
         interval: 300; running: false; repeat: false
         onTriggered: {
-            console.log('generateFilter')
             generateFilters()
         }
     }
@@ -125,7 +122,6 @@ Item {
 
     function generateTextFilters() {
         var i, f, newFilters = []
-        console.log(searchHistory)
         //generate patterns
         var tmp = []
         for (var i = 0; i < searchHistory.length; i++) {
@@ -147,13 +143,11 @@ Item {
         if (state === 'NAME_SEARCH') {
             tmpFilters = generateTextFilters()
             if (!Contacts.containsLetters(searchHistory)) {
-                console.log('has numbers')
                 phoneNumberFilter.value = phoneNumberField.replace(/ /g,'')
                 tmpFilters.push(phoneNumberFilter)
             }
 
         } else if (state === 'NUMBER_SEARCH') {
-            console.log('search for:', phoneNumberField.replace(/ /g,''))
             phoneNumberFilter.value = phoneNumberField.replace(/ /g,'')
             tmpFilters = [fakeFilter, phoneNumberFilter]
         } else {

--- a/src/qml/DialerPage/ContactDialPadSearch.qml
+++ b/src/qml/DialerPage/ContactDialPadSearch.qml
@@ -34,7 +34,6 @@ Item {
 
     signal contactSelected(QtObject contact)
 
-
     function _cartesianProduct(a) { // a = array of array
         var i, j, l, m, a1, o = [];
         if (!a || a.length == 0) return a;
@@ -49,7 +48,6 @@ Item {
         }
         return o;
     }
-
 
     function clearAll() {
         searchHistory = []
@@ -127,7 +125,6 @@ Item {
     }
 
     onContactSelected: clearAll()
-
 
     Component {
         id: firstNameFilter
@@ -226,7 +223,6 @@ Item {
                 anchors.fill: parent
                 onClicked: {
                     if (contact.phoneNumbers.length > 1) {
-
                         // try to determine the right number if user search with numbers
                         for (var i=0; i < contact.phoneNumbers.length; i++) {
                             if (contact.phoneNumbers[i].number.startsWith(phoneNumberField.replace(/ /g,''))) {
@@ -250,7 +246,6 @@ Item {
                         contactSelected(contact)
                     }
                 }
-
             }
         }
     }
@@ -264,7 +259,6 @@ Item {
 
     }
 
-
     Component {
         id: chooseNumberDialog
 
@@ -272,7 +266,6 @@ Item {
             id: popover
 
             property var contact
-
             signal selectedPhoneNumber(string number)
 
             ListView {
@@ -281,7 +274,6 @@ Item {
 
                 model: contact.phoneNumbers
                 highlightMoveDuration : 0
-
 
                 height: units.gu(6) * contact.phoneNumbers.length
                 width: parent.width
@@ -297,8 +289,6 @@ Item {
                     }
                 }
             }
-
         }
     }
-
 }

--- a/src/qml/DialerPage/ContactDialPadSearch.qml
+++ b/src/qml/DialerPage/ContactDialPadSearch.qml
@@ -126,7 +126,9 @@ Item {
         for(i = 0; i < searchPatterns.length; i++) {
             f = lastNameFilter.createObject(parent, { value: searchPatterns[i]});
             newFilters.push(f)
-            f = firstNameFilter.createObject(parent, { value: searchPatterns[i]});
+//            f = firstNameFilter.createObject(parent, { value: searchPatterns[i]});
+//            newFilters.push(f)
+            f = nameFilter.createObject(parent, { value: searchPatterns[i]});
             newFilters.push(f)
         }
         return newFilters
@@ -162,6 +164,15 @@ Item {
         DetailFilter {
             detail: ContactDetail.Name
             field: Name.LastName
+            matchFlags: DetailFilter.MatchStartsWith
+        }
+    }
+
+    Component {
+        id: nameFilter
+        DetailFilter {
+            detail: (contactModel.manager === "galera" ? ContactDetail.ExtendedDetail : ContactDetail.DisplayLabel)
+            field: (contactModel.manager === "galera" ? ExtendedDetail.Data : DisplayLabel.Label)
             matchFlags: DetailFilter.MatchStartsWith
         }
     }

--- a/src/qml/DialerPage/ContactDialPadSearch.qml
+++ b/src/qml/DialerPage/ContactDialPadSearch.qml
@@ -1,0 +1,304 @@
+/*
+ * Copyright 2020 Ubports Foundation
+ *
+ * This file is part of dialer-app.
+ *
+ * dialer-app is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * dialer-app is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import QtQuick 2.0
+import Ubuntu.Components.Popups 1.3
+import Ubuntu.Components 1.3
+import Ubuntu.Contacts 0.1
+import QtContacts 5.0
+
+Item {
+    id:root
+    objectName: "root"
+    state: "NO_FILTER"
+
+    property var searchHistory : []
+    property  string phoneNumberField: ""
+    property int nameSearchLastIndex: 0
+    property bool emptySearch: phoneNumberField.length === 0
+
+    signal contactSelected(QtObject contact)
+
+
+    function _cartesianProduct(a) { // a = array of array
+        var i, j, l, m, a1, o = [];
+        if (!a || a.length == 0) return a;
+
+        a1 = a.splice(0, 1)[0]; // the first array of a
+        a = _cartesianProduct(a);
+        for (i = 0, l = a1.length; i < l; i++) {
+            if (a && a.length) for (j = 0, m = a.length; j < m; j++)
+                    o.push(a1[i].concat(a[j]));
+            else
+                o.push(a1[i]);
+        }
+        return o;
+    }
+
+
+    function clearAll() {
+        searchHistory = []
+        nameSearchLastIndex = 0
+        state = "NO_FILTER"
+        generateFilters()
+    }
+
+    function pop() {
+        searchHistory.pop()
+        if (state === "NO_FILTER" && !emptySearch) {
+            // user have selected a contact and hit back space
+            state = "NUMBER_SEARCH"
+        } else if (searchHistory.length > 0 && searchHistory.length === nameSearchLastIndex){
+            // return to name search
+            state = "NAME_SEARCH"
+        } else if (emptySearch || phoneNumberField.length === 1) {
+            clearAll()
+        }
+
+        generateFilters()
+
+    }
+
+    function push(pattern) {
+        if (pattern && pattern.length > 0) {
+            searchHistory.push(pattern)
+            if (state === "NO_FILTER" && phoneNumberField.length === 1 && searchHistory.length === 1) {
+                //first time
+                state = "NAME_SEARCH"
+            } else {
+
+                if (state === "NAME_SEARCH" && contactModel.contacts.length === 0) {
+                    //start to search for phone numbers if no contact found
+                    state = "NUMBER_SEARCH"
+                    // store here the last time we did a textSearch
+                    nameSearchLastIndex = searchHistory.length
+                }
+            }
+
+            generateFilters()
+        }
+    }
+
+    function generateTextFilters() {
+        var i, f, newFilters = []
+
+        //generate patterns
+        var tmp = []
+        for (var i = 0; i < searchHistory.length; i++) {
+            tmp.push(searchHistory[i].split(""))
+        }
+        var searchPatterns =  _cartesianProduct(tmp)
+
+        for(i = 0; i < searchPatterns.length; i++) {
+            f = lastNameFilter.createObject(parent, { value: searchPatterns[i]});
+            newFilters.push(f)
+            f = firstNameFilter.createObject(parent, { value: searchPatterns[i]});
+            newFilters.push(f)
+        }
+        return newFilters
+    }
+
+    function generateFilters() {
+        var tmpFilters
+        if (state === 'NAME_SEARCH') {
+            tmpFilters = generateTextFilters()
+        } else if (state === 'NUMBER_SEARCH') {
+            phoneNumberFilter.value = phoneNumberField.replace(/ /g,'')
+            tmpFilters = [fakeFilter, phoneNumberFilter]
+        } else {
+            tmpFilters = [invalidFilter]
+        }
+        contactModel.filters = tmpFilters
+    }
+
+    onContactSelected: clearAll()
+
+
+    Component {
+        id: firstNameFilter
+        DetailFilter {
+            detail: ContactDetail.Name
+            field: Name.FirstName
+            matchFlags: DetailFilter.MatchStartsWith
+        }
+    }
+
+    Component {
+        id: lastNameFilter
+        DetailFilter {
+            detail: ContactDetail.Name
+            field: Name.LastName
+            matchFlags: DetailFilter.MatchStartsWith
+        }
+    }
+
+    DetailFilter {
+        id: phoneNumberFilter
+        detail: ContactDetail.PhoneNumber
+        field: PhoneNumber.Number
+        matchFlags: (DetailFilter.MatchPhoneNumber | DetailFilter.MatchStartsWith)
+    }
+
+    // mandatory fake filter used with phoneNumberFilter, otherwise we will have no result
+    DetailFilter{
+        id: fakeFilter
+        detail: ContactDetail.Timestamp
+        field: Timestamp.Timestamp
+        matchFlags: DetailFilter.MatchExactly
+        value: -1
+    }
+
+    InvalidFilter {
+        id: invalidFilter
+    }
+
+    ContactModel {
+        id: contactModel
+        objectName: "contactModel"
+        manager: "galera"
+        property alias filters: _filters.filters
+        sortOrders: [
+            SortOrder {
+                id: sortOrder
+                detail: ContactDetail.DisplayLabel
+                field: DisplayLabel.Label
+                direction: Qt.AscendingOrder
+                blankPolicy: SortOrder.BlanksLast
+                caseSensitivity: Qt.CaseInsensitive
+            }
+        ]
+
+        fetchHint: FetchHint {
+            detailTypesHint: [
+                ContactDetail.DisplayLabel,
+                ContactDetail.PhoneNumber
+            ]
+        }
+
+        filter: UnionFilter {
+            id: _filters
+            filters: [invalidFilter]
+        }
+
+        onContactsChanged: {
+            if (state === "NAME_SEARCH" && contacts.length === 0) {
+                //start to search for phone numbers if no contact found
+                state = "NUMBER_SEARCH"
+                //store here the last time we did a successfull textSearch
+                nameSearchLastIndex = searchHistory.length -1
+                generateFilters()
+            }
+        }
+
+        onErrorChanged: {
+            if (error) {
+                console.error("Contact List error:" + error)
+            }
+        }
+    }
+
+    ListView {
+        id: listView
+        objectName: "listView"
+        orientation: ListView.Horizontal
+        anchors.fill: parent
+        model: contactModel
+        spacing: units.gu(2)
+        delegate: Label {
+            fontSize: "medium"
+            text:  contact.displayLabel.label
+            MouseArea {
+                anchors.fill: parent
+                onClicked: {
+                    if (contact.phoneNumbers.length > 1) {
+
+                        // try to determine the right number if user search with numbers
+                        for (var i=0; i < contact.phoneNumbers.length; i++) {
+                            if (contact.phoneNumbers[i].number.startsWith(phoneNumberField.replace(/ /g,''))) {
+                                contact.phoneNumber.number = contact.phoneNumbers[i].number
+                                contactSelected(contact)
+                                return
+                            }
+                        }
+                        // otherwise, ask user to select the right number
+                        var dialog = PopupUtils.open(chooseNumberDialog, fakeItemPositionner, {
+                                                                       'contact': contact
+                                                                    });
+                        dialog.selectedPhoneNumber.connect(
+                                                    function(number) {
+                                                        //we replace temporarely the default phone number
+                                                        contact.phoneNumber.number = number
+                                                        PopupUtils.close(dialog);
+                                                        contactSelected(contact)
+                                                    })
+                    } else {
+                        contactSelected(contact)
+                    }
+                }
+
+            }
+        }
+    }
+
+    // fake item to allow popover to position under the listView
+    Item {
+        id: fakeItemPositionner
+        objectName: "fakeItemPositionner"
+        x: parent.width /2
+        y: units.gu(12)
+
+    }
+
+
+    Component {
+        id: chooseNumberDialog
+
+        Popover {
+            id: popover
+
+            property var contact
+
+            signal selectedPhoneNumber(string number)
+
+            ListView {
+                id: phoneNumberChoice
+                objectName: "phoneNumberChoice"
+
+                model: contact.phoneNumbers
+                highlightMoveDuration : 0
+
+
+                height: units.gu(6) * contact.phoneNumbers.length
+                width: parent.width
+
+                delegate: ListItem {
+                    divider.visible: true
+                    height: layout.height + (divider.visible ? divider.height : 0)
+                    onClicked: selectedPhoneNumber(contact.phoneNumbers[index].number)
+
+                    ListItemLayout {
+                        id: layout
+                        title.text: modelData.number
+                    }
+                }
+            }
+
+        }
+    }
+
+}

--- a/src/qml/DialerPage/ContactDialPadSearch.qml
+++ b/src/qml/DialerPage/ContactDialPadSearch.qml
@@ -79,9 +79,11 @@ Item {
     function push(pattern) {
         if (pattern && pattern.length > 0) {
             searchHistory.push(pattern)
+
             if (state === "NO_FILTER" && phoneNumberField.length === 1 && searchHistory.length === 1) {
                 //first time
                 state = "NAME_SEARCH"
+
             } else {
                 if (state === "NAME_SEARCH" && fetchComplete && contactModel.contacts.length === 0) {
                     //start to search for phone numbers if no contact found

--- a/src/qml/DialerPage/DialerPage.qml
+++ b/src/qml/DialerPage/DialerPage.qml
@@ -436,7 +436,12 @@ Page {
                         contactSearch.push(keyText)
                     }
                 }
-                onKeyPressAndHold : contactSearch.clearAll()
+                onKeyPressAndHold : {
+                    if (keycode == Qt.Key_1) {
+                        contactSearch.clearAll()
+
+                    }
+                }
             }
             Connections {
                 target: backspace

--- a/src/qml/DialerPage/DialerPage.qml
+++ b/src/qml/DialerPage/DialerPage.qml
@@ -407,7 +407,7 @@ Page {
 
         ContactDialPadSearch {
             id: contactSearch
-            height: units.gu(4)
+            height: page.compactView ? units.gu(3): units.gu(4)
             anchors {
                 top: divider.bottom
                 left: parent.left

--- a/src/qml/DialerPage/DialerPage.qml
+++ b/src/qml/DialerPage/DialerPage.qml
@@ -17,7 +17,7 @@
  */
 
 import QtContacts 5.0
-import QtQuick 2.4
+import QtQuick 2.9
 import Ubuntu.Components 1.3
 import Ubuntu.Components.Popups 1.3
 import Ubuntu.Telephony 0.1
@@ -429,6 +429,7 @@ Page {
 
             Connections {
                 target: keypad
+                enabled: mainView.settings.contactSearchWithDialPad
                 onKeyPressed : {
                     if (keycode == Qt.Key_Backspace) {
                         contactSearch.pop()
@@ -445,6 +446,7 @@ Page {
             }
             Connections {
                 target: backspace
+                enabled: mainView.settings.contactSearchWithDialPad
                 onClicked : contactSearch.pop()
                 onPressAndHold : contactSearch.clearAll()
             }

--- a/src/qml/DialerPage/DialerPage.qml
+++ b/src/qml/DialerPage/DialerPage.qml
@@ -405,7 +405,6 @@ Page {
             }
         }
 
-
         ContactDialPadSearch {
             id: contactSearch
             height: units.gu(4)
@@ -446,7 +445,6 @@ Page {
             }
 
         }
-
 
         Keypad {
             id: keypad

--- a/src/qml/DialerPage/DialerPage.qml
+++ b/src/qml/DialerPage/DialerPage.qml
@@ -203,7 +203,7 @@ Page {
         if (event.key == Qt.Key_Return || event.key == Qt.Key_Enter) {
             page.focus = false;
         }
-        keypad.keyPressed(event.key, event.text, event.text)
+        keypad.keyPressed(event.key, event.text, keypad.keyTextfromKeyCode(event.key))
     }
 
     function triggerCallAnimation() {

--- a/src/qml/DialerPage/DialerPage.qml
+++ b/src/qml/DialerPage/DialerPage.qml
@@ -203,8 +203,7 @@ Page {
         if (event.key == Qt.Key_Return || event.key == Qt.Key_Enter) {
             page.focus = false;
         }
-
-        keypad.keyPressed(event.key, event.text)
+        keypad.keyPressed(event.key, event.text, event.text)
     }
 
     function triggerCallAnimation() {
@@ -393,29 +392,74 @@ Page {
         Label {
             id: contactLabel
             anchors {
+                top: divider.bottom
                 horizontalCenter: divider.horizontalCenter
-                bottom: entryWithButtons.bottom
-                bottomMargin: units.gu(1)
+                topMargin: units.gu(1)
             }
             text: contactWatcher.isUnknown ? "" : contactWatcher.alias
             color: theme.palette.normal.backgroundSecondaryText
             opacity: text != "" ? 1 : 0
-            fontSize: "small"
+            fontSize: "medium"
             Behavior on opacity {
                 UbuntuNumberAnimation { }
             }
         }
+
+
+        ContactDialPadSearch {
+            id: contactSearch
+            height: units.gu(4)
+            anchors {
+                top: divider.bottom
+                left: parent.left
+                right: parent.right
+                topMargin: units.gu(1)
+                leftMargin: units.gu(4)
+                rightMargin: units.gu(4)
+            }
+
+            phoneNumberField: input.text
+
+            onContactSelected: {
+                input.text = contact.phoneNumber.number
+            }
+
+            Behavior on opacity {
+                UbuntuNumberAnimation { }
+            }
+
+            Connections {
+                target: keypad
+                onKeyPressed : {
+                    if (keycode == Qt.Key_Backspace) {
+                        contactSearch.pop()
+                    } else {
+                        contactSearch.push(keyText)
+                    }
+                }
+                onKeyPressAndHold : contactSearch.clearAll()
+            }
+            Connections {
+                target: backspace
+                onClicked : contactSearch.pop()
+                onPressAndHold : contactSearch.clearAll()
+            }
+
+        }
+
 
         Keypad {
             id: keypad
             showVoicemail: true
 
             anchors {
-                top: divider.bottom
+                top: contactSearch.bottom
                 left: parent.left
                 right: parent.right
                 bottom: parent.bottom
-                margins: units.gu(2)
+                leftMargin: units.gu(2)
+                rightMargin: units.gu(2)
+                bottomMargin: units.gu(3)
             }
             labelPixelSize: page.compactView ? units.dp(20) : units.dp(30)
             spacing: page.compactView ? 0 : 5

--- a/src/qml/DialerPage/Keypad.qml
+++ b/src/qml/DialerPage/Keypad.qml
@@ -30,7 +30,7 @@ Item {
     property bool showVoicemail: false
     property alias spacing: keys.columnSpacing
 
-    signal keyPressed(int keycode, string keychar)
+    signal keyPressed(int keycode, string keychar, string keyText)
     signal keyPressAndHold(int keycode, string keychar)
 
     GridLayout {
@@ -47,7 +47,7 @@ Item {
             implicitHeight: keysHeight
             label: i18n.tr("1")
             keycode: Qt.Key_1
-            onPressed: keypad.keyPressed(keycode, "1")
+            onPressed: keypad.keyPressed(keycode, "1", "1")
             onPressAndHold: keypad.keyPressAndHold(keycode, "1")
             iconSource: showVoicemail ? "voicemail" : ""
             labelFont.pixelSize: keypad.labelPixelSize
@@ -65,7 +65,7 @@ Item {
             label: i18n.tr("2")
             sublabel: i18n.tr("ABC")
             keycode: Qt.Key_2
-            onPressed: keypad.keyPressed(keycode, "2")
+            onPressed: keypad.keyPressed(keycode, "2", sublabel)
             onPressAndHold: keypad.keyPressAndHold(keycode, "2")
             labelFont.pixelSize: keypad.labelPixelSize
 
@@ -82,7 +82,7 @@ Item {
             label: i18n.tr("3")
             sublabel: i18n.tr("DEF")
             keycode: Qt.Key_3
-            onPressed: keypad.keyPressed(keycode, "3")
+            onPressed: keypad.keyPressed(keycode, "3", sublabel)
             onPressAndHold: keypad.keyPressAndHold(keycode, "3")
             labelFont.pixelSize: keypad.labelPixelSize
 
@@ -99,7 +99,7 @@ Item {
             label: i18n.tr("4")
             sublabel: i18n.tr("GHI")
             keycode: Qt.Key_4
-            onPressed: keypad.keyPressed(keycode, "4")
+            onPressed: keypad.keyPressed(keycode, "4", sublabel)
             onPressAndHold: keypad.keyPressAndHold(keycode, "4")
             labelFont.pixelSize: keypad.labelPixelSize
 
@@ -116,7 +116,7 @@ Item {
             label: i18n.tr("5")
             sublabel: i18n.tr("JKL")
             keycode: Qt.Key_5
-            onPressed: keypad.keyPressed(keycode, "5")
+            onPressed: keypad.keyPressed(keycode, "5", sublabel)
             onPressAndHold: keypad.keyPressAndHold(keycode, "5")
             labelFont.pixelSize: keypad.labelPixelSize
 
@@ -133,7 +133,7 @@ Item {
             label: i18n.tr("6")
             sublabel: i18n.tr("MNO")
             keycode: Qt.Key_6
-            onPressed: keypad.keyPressed(keycode, "6")
+            onPressed: keypad.keyPressed(keycode, "6", sublabel)
             onPressAndHold: keypad.keyPressAndHold(keycode, "6")
             labelFont.pixelSize: keypad.labelPixelSize
 
@@ -150,7 +150,7 @@ Item {
             label: i18n.tr("7")
             sublabel: i18n.tr("PQRS")
             keycode: Qt.Key_7
-            onPressed: keypad.keyPressed(keycode, "7")
+            onPressed: keypad.keyPressed(keycode, "7", sublabel)
             onPressAndHold: keypad.keyPressAndHold(keycode, "7")
             labelFont.pixelSize: keypad.labelPixelSize
 
@@ -167,7 +167,7 @@ Item {
             label: i18n.tr("8")
             sublabel: i18n.tr("TUV")
             keycode: Qt.Key_8
-            onPressed: keypad.keyPressed(keycode, "8")
+            onPressed: keypad.keyPressed(keycode, "8", sublabel)
             onPressAndHold: keypad.keyPressAndHold(keycode, "8")
             labelFont.pixelSize: keypad.labelPixelSize
 
@@ -184,7 +184,7 @@ Item {
             label: i18n.tr("9")
             sublabel: i18n.tr("WXYZ")
             keycode: Qt.Key_9
-            onPressed: keypad.keyPressed(keycode, "9")
+            onPressed: keypad.keyPressed(keycode, "9", sublabel)
             onPressAndHold: keypad.keyPressAndHold(keycode, "9")
             labelFont.pixelSize: keypad.labelPixelSize
 
@@ -202,7 +202,7 @@ Item {
             corner: Qt.BottomLeftCorner
             label: i18n.tr("*")
             keycode: Qt.Key_Asterisk
-            onPressed: keypad.keyPressed(keycode, "*")
+            onPressed: keypad.keyPressed(keycode, "*","*")
             onPressAndHold: keypad.keyPressAndHold(keycode, "*")
             labelFont.pixelSize: keypad.labelPixelSize
 
@@ -220,7 +220,7 @@ Item {
             sublabel: i18n.tr("+")
             sublabelSize: "medium"
             keycode: Qt.Key_0
-            onPressed: keypad.keyPressed(keycode, "0")
+            onPressed: keypad.keyPressed(keycode, "0", "0")
             onPressAndHold: keypad.keyPressAndHold(keycode, "0")
             labelFont.pixelSize: keypad.labelPixelSize
 
@@ -238,7 +238,7 @@ Item {
             corner: Qt.BottomRightCorner
             label: i18n.tr("#")
             keycode: Qt.Key_ssharp
-            onPressed: keypad.keyPressed(keycode, "#")
+            onPressed: keypad.keyPressed(keycode, "#", "#")
             onPressAndHold: keypad.keyPressAndHold(keycode, "#")
             labelFont.pixelSize: keypad.labelPixelSize
 

--- a/src/qml/DialerPage/Keypad.qml
+++ b/src/qml/DialerPage/Keypad.qml
@@ -33,6 +33,17 @@ Item {
     signal keyPressed(int keycode, string keychar, string keyText)
     signal keyPressAndHold(int keycode, string keychar)
 
+    function keyTextfromKeyCode(keyCode) {
+        for (var i = 0; i < keys.children.length; i++)
+        {
+            var item = keys.children[i]
+            if (item.keycode === keyCode) {
+                return item.sublabel
+            }
+        }
+        return ""
+    }
+
     GridLayout {
         id: keys
 

--- a/src/qml/LiveCallPage/LiveCall.qml
+++ b/src/qml/LiveCallPage/LiveCall.qml
@@ -97,7 +97,7 @@ Page {
             dtmfVisible = true
         }
 
-        keypad.keyPressed(event.key, event.text)
+        keypad.keyPressed(event.key, event.text, "")
     }
 
     function reportStatus(callObject, text) {

--- a/src/qml/SettingsPage/SettingsPage.qml
+++ b/src/qml/SettingsPage/SettingsPage.qml
@@ -126,6 +126,16 @@ Page {
                 enabled: (onlineAccountHelper.status === Loader.Ready) && (onlineAccountHelper.item.count > 0)
             }
 
+            ListItem.Standard {
+                control: Switch {
+                    property bool enabled: mainView.settings.contactSearchWithDialPad
+                    onEnabledChanged: checked = enabled
+                    Component.onCompleted: checked = enabled
+                    onTriggered: mainView.settings.contactSearchWithDialPad = checked
+                }
+                text: i18n.tr("Contact search with dial pad (Experimental)")
+            }
+
             Repeater {
                 model: telepathyHelper.voiceAccounts.all
 

--- a/src/qml/dialer-app.qml
+++ b/src/qml/dialer-app.qml
@@ -33,6 +33,7 @@ MainView {
     property string ussdResponseTitle: ""
     property string ussdResponseText: ""
     property alias multiplePhoneAccounts: accountsModel.multipleAccounts
+    property alias settings: generalSettings
     property QtObject account: accountsModel.defaultCallAccount
     property bool simLocked: account && account.simLocked
     property bool greeterMode: (state == "greeterMode")
@@ -149,6 +150,8 @@ MainView {
     Settings {
         id: generalSettings
         property string lastCalledPhoneNumber: ""
+        property bool contactSearchWithDialPad: true
+
     }
 
     PhoneUtils {

--- a/tests/qml/CMakeLists.txt
+++ b/tests/qml/CMakeLists.txt
@@ -21,6 +21,7 @@ if(QMLTESTRUNNER_BIN AND XVFB_RUN_BIN)
     declare_qml_test("stopwatch" tst_StopWatch.qml)
     declare_qml_test("historydelegate" tst_HistoryDelegate.qml)
     declare_qml_test("dialer_page" tst_DialerPage.qml)
+    declare_qml_test("dialpad_search" tst_DialPadSearch.qml)
 else()
     if (NOT QMLTESTRUNNER_BIN)
         message(WARNING "Qml tests disabled: qmltestrunner not found")
@@ -35,5 +36,6 @@ set(QML_TST_FILES
     tst_MainView.qml
     tst_HistoryDelegate.qml
     tst_DialerPage.qml
+    tst_DialPadSearch.qml
 )
 add_custom_target(tst_QmlFiles ALL SOURCES ${QML_TST_FILES})

--- a/tests/qml/tst_DialPadSearch.qml
+++ b/tests/qml/tst_DialPadSearch.qml
@@ -1,0 +1,321 @@
+/*
+ * Copyright 2014 Canonical Ltd.
+ *
+ * This file is part of dialer-app.
+ *
+ * dialer-app is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * dialer-app is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import QtQuick 2.2
+import QtTest 1.0
+import QtContacts 5.0
+import Ubuntu.Test 0.1
+
+
+import '../../src/qml/DialerPage'
+
+Item {
+    id: root
+
+    width: units.gu(40)
+    height: units.gu(60)
+
+
+    function emptyContacts(model) {
+        if (!model.autoUpdate)
+            model.update();
+
+        var count = model.contacts.length;
+        if (count == 0)
+            return;
+        for (var i = 0; i < count; i++) {
+            var id = model.contacts[0].contactId;
+            model.removeContact(id);
+            if (!model.autoUpdate)
+                model.update()
+            spy.wait();
+            spy.clear();
+        }
+    }
+
+    Filter {
+        id:noFilter
+    }
+
+
+    Contact {
+        id: contact1;
+        DisplayLabel {
+            label: "contactA"
+        }
+
+        Name {
+            firstName: "contactA"
+        }
+        PhoneNumber {
+            number: "1111111111"
+        }
+    }
+
+    Contact {
+        id: contact2
+
+
+        DisplayLabel {
+            label: "contactB"
+        }
+
+
+        Name {
+            firstName: "contactB"
+            lastName:"zorro"
+        }
+
+
+        PhoneNumber {
+            number: "3333333333"
+            subTypes:[PhoneNumber.Mobile]
+        }
+
+        PhoneNumber {
+            number: "4444444444"
+            subTypes:[PhoneNumber.Fax]
+        }
+
+    }
+
+
+    function appendPattern(p) {
+        dialPadSearch.phoneNumberField = dialPadSearch.phoneNumberField + p
+        dialPadSearch.push(p)
+    }
+
+    function pop() {
+        dialPadSearch.phoneNumberField = dialPadSearch.phoneNumberField.substring(0, dialPadSearch.phoneNumberField.length-1)
+        dialPadSearch.pop()
+    }
+
+    ContactDialPadSearch {
+        id: dialPadSearch
+        width:parent.width
+    }
+
+    SignalSpy {
+        id: spyOnContactSelected
+        target: dialPadSearch
+        signalName: 'contactSelected'
+    }
+
+    SignalSpy {
+        id: spyOnManagerChanged
+        signalName: 'managerChanged'
+    }
+
+    SignalSpy {
+        id: spyOnFilterChanged
+        signalName: 'filterChanged'
+    }
+
+    SignalSpy {
+        id: spyOnContactsChanged
+        signalName: 'contactsChanged'
+    }
+
+    SignalSpy {
+        id: spyOnCountChanged
+        signalName: 'countChanged'
+    }
+
+    SignalSpy {
+        id: spyOnCurrentIndexChanged
+        signalName: 'currentIndexChanged'
+    }
+
+    SignalSpy {
+        id: spyOnModelChanged
+        signalName: 'modelChanged'
+    }
+
+    TestCase {
+        id: dialPadSearchStatesTestCase
+        name: 'dialPadSearchTestCase'
+
+        when: windowShown
+
+        function init() {
+            waitForRendering(dialPadSearch);
+            dialPadSearch.phoneNumberField = ''
+            dialPadSearch.clearAll()
+        }
+
+        function cleanup() {
+            spyOnContactSelected.clear()
+        }
+
+        function test_init() {
+            tryCompare(dialPadSearch, 'state', 'NO_FILTER');
+            var listView = findChild(dialPadSearch, 'listView')
+            tryCompare(listView, 'count', 0);
+        }
+
+        function test_shouldSwitchToNameFilter() {
+            appendPattern('A')
+            verify(dialPadSearch.searchHistory.length > 0)
+            tryCompare(dialPadSearch, 'state', 'NAME_SEARCH');
+        }
+
+        function test_shouldSwitchToPhoneFilter() {
+            appendPattern('0')
+            appendPattern('1')
+            verify(dialPadSearch.searchHistory.length > 0)
+            tryCompare(dialPadSearch, 'state', 'NUMBER_SEARCH');
+        }
+
+        function test_shouldReturnToNoFilter() {
+            appendPattern('A')
+            appendPattern('B')
+            pop()
+            tryCompare(dialPadSearch, 'state', 'NO_FILTER');
+            verify(dialPadSearch.searchHistory.length == 0)
+            appendPattern('A')
+            //user have reset the field
+            dialPadSearch.clearAll()
+            tryCompare(dialPadSearch, 'state', 'NO_FILTER');
+        }
+
+        function test_shouldBackToNameFilter() {
+            appendPattern('A')
+            appendPattern('B')
+            appendPattern('C')
+            pop()
+            tryCompare(dialPadSearch, 'state', 'NAME_SEARCH');
+        }
+
+    }
+
+
+    TestCase {
+        id: contactsTestCase
+        when: windowShown
+
+
+        function initTestCase() {
+
+
+            var contactModel = findChild(dialPadSearch, 'contactModel')
+            spyOnFilterChanged.target = contactModel
+            spyOnContactsChanged.target = contactModel
+            spyOnManagerChanged.target = contactModel
+
+            //init model, reset memory db and append 2 contacts
+            contactModel.manager = "memory"
+            spyOnManagerChanged.wait()
+            //we need no filter in order to have all contacts
+            var currentFilter = contactModel.filter
+            contactModel.filter = noFilter
+            spyOnFilterChanged.wait()
+
+            emptyContacts(contactModel)
+            contactModel.saveContact(contact1);
+            spyOnContactsChanged.wait()
+            contactModel.saveContact(contact2);
+            spyOnContactsChanged.wait()
+
+            contactModel.filter = currentFilter
+            spyOnFilterChanged.wait()
+            spyOnContactsChanged.wait()
+
+            var listView = findChild(dialPadSearch, 'listView')
+            spyOnCountChanged.target = listView
+            spyOnCurrentIndexChanged.target = listView
+
+        }
+
+
+        function cleanup() {
+
+            var contactModel = findChild(dialPadSearch, 'contactModel')
+            dialPadSearch.phoneNumberField = ""
+            dialPadSearch.clearAll()
+            spyOnFilterChanged.wait()
+            spyOnCountChanged.wait()
+
+            spyOnContactSelected.clear()
+            spyOnCountChanged.clear()
+            spyOnContactsChanged.clear()
+        }
+
+        function test_asinglePhoneNumberSelection(){
+            var listView = findChild(dialPadSearch, 'listView')
+            waitForRendering(listView)
+            appendPattern('1')
+            appendPattern('1')
+            spyOnCountChanged.wait()
+            compare(listView.count, 1)
+            tryVerify(function(){ return listView.currentItem })
+            compare(listView.currentItem.text, "contactA")
+
+            mouseClick(listView.currentItem)
+            spyOnContactSelected.wait()
+            compare(spyOnContactSelected.count, 1)
+        }
+
+
+        // contact number is guessed according to phoneNumberField number
+        function test_multiPhoneNumberSelectionGuessed() {
+            var listView = findChild(dialPadSearch, 'listView')
+            appendPattern('3')
+            appendPattern('3')
+
+            spyOnCountChanged.wait()
+            tryCompare(listView, "count", 1)
+
+            tryVerify(function(){ return listView.currentItem })
+            compare(listView.currentItem.text, "contactB")
+            mouseClick(listView.currentItem)
+            spyOnContactSelected.wait()
+            compare(spyOnContactSelected.count, 1)
+
+            var args = spyOnContactSelected.signalArguments[0]
+            compare(args[0].phoneNumber.number, "3333333333")
+        }
+
+        // test user interaction to select the correct number
+        function test_multiPhoneNumberSelectionPopup() {
+            appendPattern('z')
+            spyOnCountChanged.wait()
+
+            var listView = findChild(dialPadSearch, 'listView')
+            tryVerify(function(){ return listView.currentItem })
+            compare(listView.currentItem.text, "contactB")
+
+            mouseClick(listView.currentItem)
+            wait(200) //wait popup to display
+
+            var phoneNumberChoice = findChild(root.parent, "phoneNumberChoice")
+            waitForRendering(phoneNumberChoice)
+            compare(phoneNumberChoice.count, 2)
+            verify(phoneNumberChoice.visible)
+
+            tryVerify(function(){ return phoneNumberChoice.currentItem })
+            mouseClick(phoneNumberChoice.currentItem)
+            spyOnContactSelected.wait()
+            compare(spyOnContactSelected.count, 1)
+        }
+
+
+
+
+    }
+
+}

--- a/tests/qml/tst_DialPadSearch.qml
+++ b/tests/qml/tst_DialPadSearch.qml
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Canonical Ltd.
+ * Copyright 2020 Ubports Foundation.
  *
  * This file is part of dialer-app.
  *

--- a/tests/qml/tst_DialPadSearch.qml
+++ b/tests/qml/tst_DialPadSearch.qml
@@ -247,7 +247,8 @@ Item {
             spyOnCountChanged.wait()
             compare(listView.count, 1)
             tryVerify(function(){ return listView.currentItem })
-            compare(listView.currentItem.text, "contactA")
+            var contactItem = findChild(listView.currentItem, 'contactItem')
+            compare(contactItem.text, "contactA")
 
             mouseClick(listView.currentItem)
             spyOnContactSelected.wait()
@@ -264,7 +265,8 @@ Item {
             tryCompare(listView, "count", 1)
 
             tryVerify(function(){ return listView.currentItem })
-            compare(listView.currentItem.text, "contactB")
+            var contactItem = findChild(listView.currentItem, 'contactItem')
+            compare(contactItem.text, "contactB")
             mouseClick(listView.currentItem)
             spyOnContactSelected.wait()
             compare(spyOnContactSelected.count, 1)
@@ -276,11 +278,13 @@ Item {
         // test user interaction to select the correct number
         function test_multiPhoneNumberSelectionPopup() {
             appendPattern('z')
+            appendPattern('o')
             spyOnCountChanged.wait()
 
             var listView = findChild(dialPadSearch, 'listView')
             tryVerify(function(){ return listView.currentItem })
-            compare(listView.currentItem.text, "contactB")
+            var contactItem = findChild(listView.currentItem, 'contactItem')
+            compare(contactItem.text, "contactB")
 
             mouseClick(listView.currentItem)
             wait(200) //wait popup to display

--- a/tests/qml/tst_DialPadSearch.qml
+++ b/tests/qml/tst_DialPadSearch.qml
@@ -20,8 +20,6 @@ import QtQuick 2.2
 import QtTest 1.0
 import QtContacts 5.0
 import Ubuntu.Test 0.1
-
-
 import '../../src/qml/DialerPage'
 
 Item {
@@ -30,11 +28,9 @@ Item {
     width: units.gu(40)
     height: units.gu(60)
 
-
     function emptyContacts(model) {
         if (!model.autoUpdate)
             model.update();
-
         var count = model.contacts.length;
         if (count == 0)
             return;
@@ -51,7 +47,6 @@ Item {
     Filter {
         id:noFilter
     }
-
 
     Contact {
         id: contact1;
@@ -70,17 +65,14 @@ Item {
     Contact {
         id: contact2
 
-
         DisplayLabel {
             label: "contactB"
         }
-
 
         Name {
             firstName: "contactB"
             lastName:"zorro"
         }
-
 
         PhoneNumber {
             number: "3333333333"
@@ -91,9 +83,7 @@ Item {
             number: "4444444444"
             subTypes:[PhoneNumber.Fax]
         }
-
     }
-
 
     function appendPattern(p) {
         dialPadSearch.phoneNumberField = dialPadSearch.phoneNumberField + p
@@ -203,15 +193,11 @@ Item {
 
     }
 
-
     TestCase {
         id: contactsTestCase
         when: windowShown
 
-
         function initTestCase() {
-
-
             var contactModel = findChild(dialPadSearch, 'contactModel')
             spyOnFilterChanged.target = contactModel
             spyOnContactsChanged.target = contactModel
@@ -238,12 +224,10 @@ Item {
             var listView = findChild(dialPadSearch, 'listView')
             spyOnCountChanged.target = listView
             spyOnCurrentIndexChanged.target = listView
-
         }
 
 
         function cleanup() {
-
             var contactModel = findChild(dialPadSearch, 'contactModel')
             dialPadSearch.phoneNumberField = ""
             dialPadSearch.clearAll()
@@ -269,7 +253,6 @@ Item {
             spyOnContactSelected.wait()
             compare(spyOnContactSelected.count, 1)
         }
-
 
         // contact number is guessed according to phoneNumberField number
         function test_multiPhoneNumberSelectionGuessed() {
@@ -312,10 +295,5 @@ Item {
             spyOnContactSelected.wait()
             compare(spyOnContactSelected.count, 1)
         }
-
-
-
-
     }
-
 }


### PR DESCRIPTION
fixes #98

From the idea of hendrikscheewel. We search for firstname or lastname (starting with). If no contacts found with letters then try with phone numbers
We can disable/enable this feature in settings 

This is the continuation of previous PR: 
https://github.com/ubports/dialer-app/pull/142 and reverted by https://github.com/ubports/dialer-app/pull/152

Due to latency and instability of the contact database, queries result can be freezed.
That feature should be marked as experimental in changelog

![screenshot20210331_162112761](https://user-images.githubusercontent.com/11663835/113159977-57e1ac80-923d-11eb-8016-601059b1eba3.png)
![screenshot20210331_161904799](https://user-images.githubusercontent.com/11663835/113160003-5e702400-923d-11eb-8f09-7e94c7010185.png)


