### PR TITLE
contact search with dial pad

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 project(dialer-app)
 cmake_minimum_required(VERSION 2.8)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Werror -Wextra")
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
 set(DESKTOP_FILE dialer-app.desktop)
 
@@ -41,7 +42,7 @@ set(CMAKE_AUTOMOC ON)
 configure_file(config.h.in ${CMAKE_CURRENT_BINARY_DIR}/config.h @ONLY)
 
 find_package(Qt5Core)
-#find_package(Qt5Contacts)
+find_package(Qt5Contacts)
 find_package(Qt5DBus)
 #find_package(Qt5Gui)
 #find_package(Qt5Multimedia)

--- a/clickable.json
+++ b/clickable.json
@@ -1,4 +1,4 @@
 {
   "builder": "cmake",
-  "build_args": "-DCLICK_MODE=ON -DENABLE_TESTS=OFF"
+  "build_args": "-DCLICK_MODE=ON -DENABLE_TESTS=OFF -DCMAKE_BUILD_TYPE=Debug"
 }

--- a/clickable.json
+++ b/clickable.json
@@ -1,5 +1,4 @@
 {
   "builder": "cmake",
   "build_args": "-DCLICK_MODE=ON -DENABLE_TESTS=OFF"
-
 }

--- a/debian/control
+++ b/debian/control
@@ -15,6 +15,7 @@ Build-Depends:
  qml-module-qttest,
  qml-module-ubuntu-components,
  qtbase5-dev (>= 5.0),
+ qtpim5-dev,
  qtdeclarative5-dev (>= 5.0),
  qtdeclarative5-dev-tools,
  qtdeclarative5-ubuntu-addressbook0.1,

--- a/po/CMakeLists.txt
+++ b/po/CMakeLists.txt
@@ -30,7 +30,7 @@ endforeach(PO_FILE)
 
 find_program(XGETTEXT_EXECUTABLE xgettext)
 if(XGETTEXT_EXECUTABLE)
-    add_custom_target(${POT_FILE}
+    add_custom_target(${POT_FILE} ALL
               COMMENT "Generating translation template"
               COMMAND ${INTLTOOL_EXTRACT} --update --type=gettext/ini
                       --srcdir=${CMAKE_CURRENT_SOURCE_DIR} ${DESKTOP_FILE_IN_IN}

--- a/po/dialer-app.pot
+++ b/po/dialer-app.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-12-16 13:22+0000\n"
+"POT-Creation-Date: 2022-01-17 12:45+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: ../src/qml/DialerPage/Keypad.qml:239
+#: ../src/qml/DialerPage/Keypad.qml:250
 msgid "#"
 msgstr ""
 
@@ -87,20 +87,20 @@ msgstr[1] ""
 msgid "(%1)"
 msgstr ""
 
-#: ../src/qml/DialerPage/Keypad.qml:203
+#: ../src/qml/DialerPage/Keypad.qml:214
 msgid "*"
 msgstr ""
 
 #: ../src/qml/DialerPage/DialerBottomEdge.qml:26
-#: ../src/qml/DialerPage/Keypad.qml:220
+#: ../src/qml/DialerPage/Keypad.qml:231
 msgid "+"
 msgstr ""
 
-#: ../src/qml/DialerPage/Keypad.qml:219
+#: ../src/qml/DialerPage/Keypad.qml:230
 msgid "0"
 msgstr ""
 
-#: ../src/qml/DialerPage/Keypad.qml:48
+#: ../src/qml/DialerPage/Keypad.qml:59
 msgid "1"
 msgstr ""
 
@@ -108,39 +108,39 @@ msgstr ""
 msgid "1 year"
 msgstr ""
 
-#: ../src/qml/DialerPage/Keypad.qml:65
+#: ../src/qml/DialerPage/Keypad.qml:76
 msgid "2"
 msgstr ""
 
-#: ../src/qml/DialerPage/Keypad.qml:82
+#: ../src/qml/DialerPage/Keypad.qml:93
 msgid "3"
 msgstr ""
 
-#: ../src/qml/DialerPage/Keypad.qml:99
+#: ../src/qml/DialerPage/Keypad.qml:110
 msgid "4"
 msgstr ""
 
-#: ../src/qml/DialerPage/Keypad.qml:116
+#: ../src/qml/DialerPage/Keypad.qml:127
 msgid "5"
 msgstr ""
 
-#: ../src/qml/DialerPage/Keypad.qml:133
+#: ../src/qml/DialerPage/Keypad.qml:144
 msgid "6"
 msgstr ""
 
-#: ../src/qml/DialerPage/Keypad.qml:150
+#: ../src/qml/DialerPage/Keypad.qml:161
 msgid "7"
 msgstr ""
 
-#: ../src/qml/DialerPage/Keypad.qml:167
+#: ../src/qml/DialerPage/Keypad.qml:178
 msgid "8"
 msgstr ""
 
-#: ../src/qml/DialerPage/Keypad.qml:184
+#: ../src/qml/DialerPage/Keypad.qml:195
 msgid "9"
 msgstr ""
 
-#: ../src/qml/DialerPage/Keypad.qml:66
+#: ../src/qml/DialerPage/Keypad.qml:77
 msgid "ABC"
 msgstr ""
 
@@ -174,15 +174,15 @@ msgstr ""
 msgid "Call"
 msgstr ""
 
-#: ../src/qml/dialer-app.qml:616
+#: ../src/qml/dialer-app.qml:618
 msgid "Call Barring"
 msgstr ""
 
-#: ../src/qml/dialer-app.qml:627
+#: ../src/qml/dialer-app.qml:629
 msgid "Call Forwarding"
 msgstr ""
 
-#: ../src/qml/dialer-app.qml:638
+#: ../src/qml/dialer-app.qml:640
 msgid "Call Waiting"
 msgstr ""
 
@@ -225,18 +225,18 @@ msgstr ""
 msgid "Call waiting"
 msgstr ""
 
-#: ../src/qml/DialerPage/DialerPage.qml:556
+#: ../src/qml/DialerPage/DialerPage.qml:605
 #: ../src/qml/LiveCallPage/ConferenceCallDisplay.qml:113
 #: ../src/qml/LiveCallPage/LiveCall.qml:490
 #: ../src/qml/LiveCallPage/MultiCallDisplay.qml:108
 msgid "Calling"
 msgstr ""
 
-#: ../src/qml/dialer-app.qml:649
+#: ../src/qml/dialer-app.qml:651
 msgid "Calling Line Presentation"
 msgstr ""
 
-#: ../src/qml/dialer-app.qml:661
+#: ../src/qml/dialer-app.qml:663
 msgid "Calling Line Restriction"
 msgstr ""
 
@@ -287,11 +287,11 @@ msgstr ""
 msgid "Confirm"
 msgstr ""
 
-#: ../src/qml/dialer-app.qml:655
+#: ../src/qml/dialer-app.qml:657
 msgid "Connected Line Presentation"
 msgstr ""
 
-#: ../src/qml/dialer-app.qml:667
+#: ../src/qml/dialer-app.qml:669
 msgid "Connected Line Restriction"
 msgstr ""
 
@@ -302,6 +302,10 @@ msgstr ""
 
 #: ../src/qml/SettingsPage/CallForwarding.qml:299
 msgid "Contact not associated with any phone number."
+msgstr ""
+
+#: ../src/qml/SettingsPage/SettingsPage.qml:136
+msgid "Contact search with dial pad (Experimental)"
 msgstr ""
 
 #: ../src/qml/ContactsPage/ContactsPage.qml:102
@@ -317,7 +321,7 @@ msgstr ""
 msgid "Could not forward to this contact"
 msgstr ""
 
-#: ../src/qml/DialerPage/Keypad.qml:83
+#: ../src/qml/DialerPage/Keypad.qml:94
 msgid "DEF"
 msgstr ""
 
@@ -379,7 +383,7 @@ msgstr ""
 msgid "Emergency Calls"
 msgstr ""
 
-#: ../src/qml/DialerPage/DialerPage.qml:514
+#: ../src/qml/DialerPage/DialerPage.qml:563
 msgid "Emergency call"
 msgstr ""
 
@@ -387,7 +391,7 @@ msgstr ""
 msgid "Enter a country code"
 msgstr ""
 
-#: ../src/qml/DialerPage/DialerPage.qml:332
+#: ../src/qml/DialerPage/DialerPage.qml:331
 #: ../src/qml/SettingsPage/CallForwardItem.qml:171
 msgid "Enter a number"
 msgstr ""
@@ -447,7 +451,7 @@ msgstr ""
 msgid "Forward to"
 msgstr ""
 
-#: ../src/qml/DialerPage/Keypad.qml:100
+#: ../src/qml/DialerPage/Keypad.qml:111
 msgid "GHI"
 msgstr ""
 
@@ -481,7 +485,7 @@ msgstr ""
 msgid "Invalid USSD code"
 msgstr ""
 
-#: ../src/qml/DialerPage/Keypad.qml:117
+#: ../src/qml/DialerPage/Keypad.qml:128
 msgid "JKL"
 msgstr ""
 
@@ -500,7 +504,7 @@ msgid ""
 "between them"
 msgstr ""
 
-#: ../src/qml/DialerPage/Keypad.qml:134
+#: ../src/qml/DialerPage/Keypad.qml:145
 msgid "MNO"
 msgstr ""
 
@@ -526,7 +530,7 @@ msgstr ""
 msgid "No"
 msgstr ""
 
-#: ../src/qml/dialer-app.qml:384
+#: ../src/qml/dialer-app.qml:386
 msgid "No SIM card selected"
 msgstr ""
 
@@ -534,8 +538,8 @@ msgstr ""
 msgid "No calls"
 msgstr ""
 
-#: ../src/qml/DialerPage/DialerPage.qml:166 ../src/qml/dialer-app.qml:403
-#: ../src/qml/dialer-app.qml:408
+#: ../src/qml/DialerPage/DialerPage.qml:166 ../src/qml/dialer-app.qml:405
+#: ../src/qml/dialer-app.qml:410
 msgid "No network"
 msgstr ""
 
@@ -582,7 +586,7 @@ msgstr ""
 msgid "Outgoing"
 msgstr ""
 
-#: ../src/qml/DialerPage/Keypad.qml:151
+#: ../src/qml/DialerPage/Keypad.qml:162
 msgid "PQRS"
 msgstr ""
 
@@ -638,7 +642,7 @@ msgstr ""
 msgid "Private number"
 msgstr ""
 
-#: ../src/qml/DialerPage/DialerPage.qml:569
+#: ../src/qml/DialerPage/DialerPage.qml:618
 #: ../src/qml/HistoryPage/HistoryPage.qml:47
 msgid "Recent"
 msgstr ""
@@ -743,20 +747,20 @@ msgstr ""
 msgid "Switch to default SIM:"
 msgstr ""
 
-#: ../src/qml/DialerPage/Keypad.qml:168
+#: ../src/qml/DialerPage/Keypad.qml:179
 msgid "TUV"
 msgstr ""
 
-#: ../src/qml/dialer-app.qml:409
+#: ../src/qml/dialer-app.qml:411
 #, qt-format
 msgid "There is currently no network on %1"
 msgstr ""
 
-#: ../src/qml/dialer-app.qml:403 ../src/qml/dialer-app.qml:410
+#: ../src/qml/dialer-app.qml:405 ../src/qml/dialer-app.qml:412
 msgid "There is currently no network."
 msgstr ""
 
-#: ../src/qml/DialerPage/DialerPage.qml:514
+#: ../src/qml/DialerPage/DialerPage.qml:563
 msgid "This is not an emergency number."
 msgstr ""
 
@@ -783,7 +787,7 @@ msgstr ""
 msgid "Voicemail"
 msgstr ""
 
-#: ../src/qml/DialerPage/Keypad.qml:185
+#: ../src/qml/DialerPage/Keypad.qml:196
 msgid "WXYZ"
 msgstr ""
 
@@ -796,7 +800,7 @@ msgstr ""
 msgid "You have to disable flight mode in order to make calls"
 msgstr ""
 
-#: ../src/qml/dialer-app.qml:384
+#: ../src/qml/dialer-app.qml:386
 msgid "You need to select a SIM card"
 msgstr ""
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,17 +2,21 @@ set(DIALER_APP dialer-app)
 
 set(dialer_app_HDRS
     dialerapplication.h
+    dialpadsearch.h
+    contactutils.h
     )
 
 set(dialer_app_SRCS
     dialerapplication.cpp
+    dialpadsearch.cpp
+    contactutils.cpp
     main.cpp
     )
 
 add_executable(${DIALER_APP}
     ${dialer_app_SRCS}
     )
-qt5_use_modules(${DIALER_APP} Core DBus Gui Qml Quick)
+qt5_use_modules(${DIALER_APP} Core DBus Gui Qml Quick Contacts)
 
 include_directories(
     ${CMAKE_CURRENT_BINARY_DIR}

--- a/src/contactutils.cpp
+++ b/src/contactutils.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Ubports Foundation.
+ *
+ * This file is part of dialer-app.
+ *
+ * dialer-app is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * dialer-app is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "contactutils.h"
+
+QTCONTACTS_USE_NAMESPACE
+
+namespace ContactUtils
+{
+
+QContactManager *sharedManager(const QString &engine)
+{
+    QString finalEngine = engine;
+    static QContactManager *instance = new QContactManager(finalEngine);
+
+    return instance;
+}
+
+}

--- a/src/contactutils.h
+++ b/src/contactutils.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 Ubports Foundation.
+ *
+ * This file is part of dialer-app.
+ *
+ * dialer-app is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * dialer-app is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef CONTACTUTILS_H
+#define CONTACTUTILS_H
+
+#include <QContactManager>
+
+QTCONTACTS_USE_NAMESPACE
+
+namespace ContactUtils
+{
+    QContactManager *sharedManager(const QString &engine = "galera");
+}
+
+#endif // CONTACTUTILS_H

--- a/src/dialerapplication.cpp
+++ b/src/dialerapplication.cpp
@@ -17,7 +17,7 @@
  */
 
 #include "dialerapplication.h"
-
+#include "dialpadsearch.h"
 #include <QDir>
 #include <QUrl>
 #include <QUrlQuery>
@@ -149,7 +149,8 @@ bool DialerApplication::setup()
     if (!pluginPath.isNull()) {
         m_view->engine()->addImportPath(pluginPath);
     }
-
+    const char* uri = "dialerapp.private";
+    qmlRegisterType<DialPadSearch>(uri, 0, 1, "DialPadSearch");
     m_view->engine()->setBaseUrl(QUrl::fromLocalFile(dialerAppDirectory()));
     m_view->setSource(QUrl::fromLocalFile(QString("%1/dialer-app.qml").arg(dialerAppDirectory())));
     if (m_fullScreen) {

--- a/src/dialpadsearch.cpp
+++ b/src/dialpadsearch.cpp
@@ -1,0 +1,435 @@
+/*
+ * Copyright 2020 Ubports Foundation.
+ *
+ * This file is part of dialer-app.
+ *
+ * dialer-app is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * dialer-app is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "dialpadsearch.h"
+#include "contactutils.h"
+#include <QDebug>
+#include <QString>
+#include <QContactDetail>
+#include <QContactManager>
+#include <QContactUnionFilter>
+#include <QContactDetailFilter>
+#include <QContactName>
+#include <QContactExtendedDetail>
+#include <QContactFetchHint>
+#include <QContactDisplayLabel>
+#include <QContactSortOrder>
+#include <QContactFavorite>
+
+#include <QContactPhoneNumber>
+#include <QContactTimestamp>
+#include <QContactAbstractRequest>
+
+
+Contact::Contact(const QString &displayLabel, const QStringList &phoneNumbers)
+    : mDisplayLabel(displayLabel), mPhoneNumbers(phoneNumbers)
+{
+}
+
+QString Contact::displayLabel() const
+{
+    return mDisplayLabel;
+}
+
+QStringList Contact::phoneNumbers() const
+{
+    return mPhoneNumbers;
+}
+
+DialPadSearch::DialPadSearch(QObject *parent): QAbstractListModel(parent),
+    mRequest(0),  mSearchHistory(), mState("NO_FILTER"), mCountryCode(-1), mNameSearchLastIndex(-1), mRequestCompleted(false)
+{
+}
+
+DialPadSearch::~DialPadSearch()
+{
+    if (mRequest) {
+        mRequest->cancel();
+        delete mRequest;
+    }
+}
+
+QString DialPadSearch::phoneNumber() const
+{
+    return mPhoneNumber;
+}
+
+void DialPadSearch::setPhoneNumber(const QString &phoneNumber)
+{
+    QString tmpNumber = QString(phoneNumber).replace(" ", "");
+    if (mPhoneNumber.length() > 0) {
+        int len = qMin(tmpNumber.length(), mPhoneNumber.length());
+        if (!tmpNumber.startsWith(mPhoneNumber.left(len))) {
+                // in case user set a different number from the contact page or outside of the app
+                clearAll();
+        }
+    }
+    mPhoneNumber = tmpNumber;
+}
+
+int DialPadSearch::countryCode() const
+{
+    return mCountryCode;
+}
+
+void DialPadSearch::setCountryCode(int countryCode)
+{
+    mCountryCode = countryCode;
+}
+
+QString DialPadSearch::state() const
+{
+    return mState;
+}
+
+void DialPadSearch::setState(const QString &state)
+{
+    if (!state.isEmpty() && state != mState) {
+        mState = state;
+        Q_EMIT stateChanged();
+    }
+}
+
+void DialPadSearch::setManager(const QString &smanager)
+{
+    if (mManager != smanager) {
+        mManager = smanager;
+        Q_EMIT managerChanged();
+        qDebug() << "manager set to:" << mManager;
+    }
+}
+
+QString DialPadSearch::manager() const
+{
+    return mManager;
+}
+
+void DialPadSearch::push(const QString &pattern)
+{
+    if (pattern.isEmpty()) return;
+
+    mSearchHistory << pattern;
+
+    QString currentState;
+    if (state() == "NO_FILTER") {
+        if (pattern == "0" || pattern == "1") {
+            currentState = "NUMBER_SEARCH";
+        // start searching for name first, but don't start before at least to digits entered
+        } else if (mSearchHistory.count() == 2) {
+            currentState = "NAME_SEARCH";
+        }
+    }
+    setState(currentState);
+
+    if (state() == "NUMBER_SEARCH") {
+        // no need to retrieve too many contacts if we are searching for numbers
+        // for non international number, start to search when we have 3 digits
+        // for international number, start to search 2 digits after the prefix
+        if (mPhoneNumber.count() < 3 || (mPhoneNumber.startsWith("+") && mPhoneNumber.count() < QString::number(mCountryCode).count() + 3)) {
+            return;
+        }
+    }
+
+    generateFilters();
+
+}
+
+void DialPadSearch::pop()
+{
+    if (!mSearchHistory.isEmpty()) {
+        mSearchHistory.pop_back();
+    }
+
+    QString currentState;
+    if (mState == "NO_FILTER" && !mPhoneNumber.isEmpty()) {
+        // user have selected a contact and hit back space
+        currentState = "NUMBER_SEARCH";
+    } else if (!mSearchHistory.isEmpty() && mSearchHistory.count() == mNameSearchLastIndex){
+        // return to name search
+        currentState = "NAME_SEARCH";
+    } else if (mPhoneNumber.isEmpty() || mPhoneNumber.count() == 1) {
+        clearAll();
+
+    }
+    setState(currentState);
+
+    // no need to retrieve too many contacts if we are searching for numbers
+    if (mState == "NUMBER_SEARCH") {
+        if (mPhoneNumber.count() < 3 || (mPhoneNumber.startsWith("+") && mPhoneNumber.count() < QString::number(mCountryCode).count() + 3)) {
+            clearModel();
+            return;
+        }
+    }
+
+    generateFilters();
+}
+
+void DialPadSearch::startSearching(const QContactFilter &filter)
+{
+    // cancel current request if necessary
+    if (mRequest) {
+        mRequest->cancel();
+        mRequest->deleteLater();
+    }
+
+    QContactFetchHint fetchHint;
+    fetchHint.setDetailTypesHint({QContactDetail::TypeDisplayLabel, QContactDetail::TypePhoneNumber, QContactDetail::TypeFavorite});
+
+    QContactSortOrder sortOrder;
+    sortOrder.setDetailType(QContactDetail::TypeDisplayLabel, QContactDisplayLabel::FieldLabel);
+    sortOrder.setDirection(Qt::AscendingOrder);
+    sortOrder.setBlankPolicy(QContactSortOrder::BlanksLast);
+    sortOrder.setCaseSensitivity(Qt::CaseSensitive);
+
+    mRequest = new QContactFetchRequest(this);
+    mRequest->setManager(ContactUtils::sharedManager(mManager));
+    mRequest->setFilter(filter);
+    mRequest->setFetchHint(fetchHint);
+    mRequest->setSorting({sortOrder});
+
+    connect(mRequest, SIGNAL(resultsAvailable()), SLOT(onResultsAvailable()));
+    connect(mRequest, SIGNAL(stateChanged(QContactAbstractRequest::State)),
+                          SLOT(onRequestStateChanged(QContactAbstractRequest::State)));
+
+    mRequestCompleted = false;
+    mRequest->start();
+}
+
+void DialPadSearch::onRequestStateChanged(QContactAbstractRequest::State state)
+{
+    QContactFetchRequest *request = mRequest;
+    if (request && state == QContactAbstractRequest::FinishedState) {
+        mRequestCompleted = true;
+        mRequest = 0;
+        request->deleteLater();
+
+        // if we got no results and we were in Name search, switch to number search
+        if (request->contacts().isEmpty() && mState == "NAME_SEARCH") {
+            //start to search for phone numbers if no contact found
+            setState("NUMBER_SEARCH");
+            //store here the last time we did a successfull textSearch
+            mNameSearchLastIndex = mSearchHistory.count() -1;
+            clearModel();
+            generateFilters();
+        }
+    }
+}
+
+void DialPadSearch::onResultsAvailable()
+{
+    QContactFetchRequest *request = qobject_cast<QContactFetchRequest*>(sender());
+
+    int favoritePos = 0;
+    beginResetModel();
+    mContacts.clear();
+    if(request && request->contacts().size() > 0) {
+        for (const auto& resultContact: request->contacts()) {
+            QStringList phoneNumbers;
+            for(const QContactPhoneNumber phoneNumber: resultContact.details(QContactDetail::TypePhoneNumber)) {
+                phoneNumbers << phoneNumber.number();
+            }
+
+            if (!phoneNumbers.isEmpty()) {
+                QString displayLabel = resultContact.detail(QContactDetail::TypeDisplayLabel).value(QContactDisplayLabel::FieldLabel).toString();
+
+                bool isFavorite = resultContact.detail(QContactDetail::TypeFavorite).value(QContactFavorite::FieldFavorite).toBool();
+
+                Contact contact = Contact(displayLabel, phoneNumbers);
+                // show favorite first
+                if (isFavorite) {
+                    mContacts.insert(favoritePos, contact);
+                    favoritePos++;
+                } else {
+                    mContacts << contact;
+                }
+            }
+        }
+    }
+    endResetModel();
+    Q_EMIT rowCountChanged();
+
+}
+
+void DialPadSearch::generateFilters()
+{
+    QContactFilter filter;
+
+    if (mState == "NAME_SEARCH") {
+
+        QContactUnionFilter unionFilter;
+        unionFilter.setFilters(generateTextFilters());
+        filter = unionFilter;
+
+    } else if (mState == "NUMBER_SEARCH") {
+
+        QContactUnionFilter unionFilter;
+        QList<QContactFilter> filters;
+
+        //a fake filter is needed with the phonumberFilter, otherwise no result will be found
+        QContactDetailFilter mFakeFilter;
+        mFakeFilter.setDetailType(QContactDetail::TypeTimestamp, QContactTimestamp::FieldCreationTimestamp);
+        mFakeFilter.setMatchFlags(QContactFilter::MatchExactly);
+        mFakeFilter.setValue(-1);
+        filters << mFakeFilter;
+
+        QContactDetailFilter mPhoneNumberFilter;
+        mPhoneNumberFilter.setDetailType(QContactDetail::TypePhoneNumber, QContactPhoneNumber::FieldNumber);
+        mPhoneNumberFilter.setMatchFlags(QContactFilter::MatchPhoneNumber | QContactFilter::MatchStartsWith);
+        mPhoneNumberFilter.setValue(mPhoneNumber);
+        filters << mPhoneNumberFilter;
+
+        if (mPhoneNumber.startsWith("0") && mCountryCode > -1) {
+            // when number start with 0, try to search also by adding the international region prefix, e.g +33
+            QString number = QStringLiteral("+%1%2").arg(mCountryCode).arg(mPhoneNumber.right(mPhoneNumber.count() - 1));
+            QContactDetailFilter internationalPhoneFilter;
+            internationalPhoneFilter.setDetailType(QContactDetail::TypePhoneNumber, QContactPhoneNumber::FieldNumber);
+            internationalPhoneFilter.setMatchFlags(QContactFilter::MatchPhoneNumber | QContactFilter::MatchStartsWith);
+            internationalPhoneFilter.setValue(number);
+            filters << internationalPhoneFilter;
+
+        } else if (mCountryCode > -1 && mPhoneNumber.startsWith(QStringLiteral("+%1").arg(mCountryCode))) {
+            // when start with international prefix, try also to look for numbers starting with 0
+            QString prefix = QStringLiteral("+%1").arg(mCountryCode);
+            QString number = QStringLiteral("0%1").arg(mPhoneNumber.right(mPhoneNumber.count() - prefix.size()));
+            QContactDetailFilter localPhoneFilter;
+            localPhoneFilter.setDetailType(QContactDetail::TypePhoneNumber, QContactPhoneNumber::FieldNumber);
+            localPhoneFilter.setMatchFlags(QContactFilter::MatchPhoneNumber | QContactFilter::MatchStartsWith);
+            localPhoneFilter.setValue(number);
+            filters << localPhoneFilter;
+        }
+
+        unionFilter.setFilters(filters);
+        filter = unionFilter;
+    } else {
+        //start with an invalid filter, otherwise backend return all contacts
+        QContactInvalidFilter mInvalidFilter;
+        filter = mInvalidFilter;
+    }
+
+    startSearching(filter);
+}
+
+void DialPadSearch::clearModel()
+{
+    beginResetModel();
+    mContacts.clear();
+    endResetModel();
+    Q_EMIT rowCountChanged();
+}
+
+void DialPadSearch::clearAll()
+{
+    mSearchHistory.clear();
+    mNameSearchLastIndex = -1;
+    setState("NO_FILTER");
+    clearModel();
+}
+
+QVariantMap DialPadSearch::get(int i) const
+{
+    QVariantMap item;
+    QHash<int, QByteArray> roles = roleNames();
+
+    QModelIndex modelIndex = index(i, 0);
+    if (modelIndex.isValid()) {
+        Q_FOREACH(int role, roles.keys()) {
+            QString roleName = QString::fromUtf8(roles.value(role));
+            item.insert(roleName, data(modelIndex, role));
+        }
+    }
+    return item;
+}
+
+QList<QContactFilter> DialPadSearch::generateTextFilters()
+{
+    QList<QList<QString>> tempPatterns;
+    for (const auto& pattern: mSearchHistory ) {
+        tempPatterns << pattern.split("", QString::SkipEmptyParts);
+    }
+    QList<QString> patterns =  cartesianProduct(tempPatterns);
+    QList<QContactFilter> filters;
+
+    for (const auto& pattern : patterns) {
+        QContactDetailFilter nameFilter;
+        nameFilter.setDetailType(QContactDetail::TypeName, QContactName::FieldLastName);
+        nameFilter.setMatchFlags(QContactFilter::MatchStartsWith);
+        nameFilter.setValue(pattern);
+
+        filters << nameFilter;
+
+        QContactDetailFilter displayLabelFilter;
+        displayLabelFilter.setDetailType(QContactDetail::TypeExtendedDetail,QContactExtendedDetail::FieldData );
+        displayLabelFilter.setMatchFlags(QContactFilter::MatchStartsWith);
+        displayLabelFilter.setValue(pattern);
+
+        filters << displayLabelFilter;
+    }
+
+    return filters;
+}
+
+QList<QString> DialPadSearch::cartesianProduct(const QList<QList<QString>>& v)
+{
+    QList<QList<QString>> s = {{}};
+
+    for (const auto& u : v) {
+        QList<QList<QString>> r;
+        for (const auto& x : s) {
+            for (const auto y : u) {
+                r.push_back(x);
+                r.back().push_back(y);
+            }
+        }
+        s = std::move(r);
+    }
+    QList<QString> result;
+    for (const auto& patterns : s) {
+        result << patterns.join("");
+    }
+    return result;
+}
+
+
+QHash<int, QByteArray> DialPadSearch::roleNames() const
+{
+    QHash<int, QByteArray> roles;
+    roles[ContactDisplayLabelRole] = "displayLabel";
+    roles[ContactPhoneNumbersRole] = "phoneNumbers";
+
+    return roles;
+}
+
+int DialPadSearch::rowCount(const QModelIndex & parent) const
+{
+    Q_UNUSED(parent);
+    return mContacts.count();
+}
+
+QVariant DialPadSearch::data(const QModelIndex & index, int role) const
+{
+    if (index.row() < 0 || index.row() >= mContacts.count())
+        return QVariant();
+
+    const Contact &contact = mContacts[index.row()];
+    if (role == ContactDisplayLabelRole)
+        return QVariant::fromValue(contact.displayLabel());
+    else if (role == ContactPhoneNumbersRole) {
+        return QVariant::fromValue(contact.phoneNumbers());
+    } else {
+        return QVariant();
+    }
+}

--- a/src/dialpadsearch.h
+++ b/src/dialpadsearch.h
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2020 Ubports Foundation.
+ *
+ * This file is part of dialer-app.
+ *
+ * dialer-app is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * dialer-app is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef DIALPADSEARCH_H
+#define DIALPADSEARCH_H
+
+#include <QObject>
+#include <QContact>
+#include <QContactManager>
+#include <QContactAbstractRequest>
+#include <QContactFetchRequest>
+#include <QtContacts/QContactUnionFilter>
+#include <QtContacts/QContactDetailFilter>
+#include <QContactInvalidFilter>
+#include <QAbstractListModel>
+
+QTCONTACTS_USE_NAMESPACE
+
+class Contact
+{
+public:
+    Contact(const QString &displayLabel, const QStringList &phoneNumbers);
+
+    QString displayLabel() const;
+    QStringList phoneNumbers() const;
+
+private:
+    QString mDisplayLabel;
+    QStringList mPhoneNumbers;
+
+};
+
+class DialPadSearch : public QAbstractListModel
+{
+    Q_OBJECT
+
+    Q_PROPERTY(int count READ rowCount NOTIFY rowCountChanged)
+    Q_PROPERTY(QString phoneNumber READ phoneNumber WRITE setPhoneNumber)
+    Q_PROPERTY(int countryCode READ countryCode WRITE setCountryCode)
+    Q_PROPERTY(QString manager READ manager WRITE setManager NOTIFY managerChanged)
+    Q_PROPERTY(QString state READ state WRITE setState NOTIFY stateChanged)
+
+public:
+    DialPadSearch(QObject *parent = 0);
+    ~DialPadSearch();
+
+    enum ContactRoles {
+        ContactDisplayLabelRole = Qt::UserRole + 1,
+        ContactPhoneNumbersRole,
+    };
+    // reimplemented from QAbstractListModel
+    QHash<int, QByteArray> roleNames() const;
+    int rowCount(const QModelIndex& parent=QModelIndex()) const;
+    QVariant data(const QModelIndex& index, int role) const;
+
+    QString phoneNumber() const;
+    void setPhoneNumber(const QString &phoneNumber);
+    int countryCode() const;
+    void setCountryCode(int countryCode);
+    QString state() const;
+    void setState(const QString &state);
+    void setManager(const QString &mContactManager);
+    QString manager() const;
+
+    Q_INVOKABLE void push(const QString& pattern);
+    Q_INVOKABLE void pop();
+    Q_INVOKABLE void clearAll();
+    Q_INVOKABLE QVariantMap get(int index) const;
+
+
+protected Q_SLOTS:
+    void onResultsAvailable();
+    void onRequestStateChanged(QContactAbstractRequest::State state);
+
+Q_SIGNALS:
+    void stateChanged();
+    void rowCountChanged();
+    void managerChanged();
+
+private:
+    QContactFetchRequest *mRequest;
+    QList<Contact> mContacts;
+    QList<QString> mSearchHistory;
+    QString mState;
+    QString mPhoneNumber;
+    QString mManager;
+    int mCountryCode;
+    int mNameSearchLastIndex;
+    bool mRequestCompleted;
+
+    void startSearching(const QContactFilter &filter);
+    void generateFilters();
+    void clearModel();
+    QList<QContactFilter> generateTextFilters();
+    QList<QString> cartesianProduct(const QList<QList<QString>>& lists);
+};
+
+#endif // DIALPADSEARCH_H

--- a/src/qml/DialerPage/ContactDialPadSearch.qml
+++ b/src/qml/DialerPage/ContactDialPadSearch.qml
@@ -26,9 +26,8 @@ import dialerapp.private 0.1
 Item {
     id:root
     objectName: "root"
-    state: dialPadSearch.state
 
-    property  string phoneNumberField: ""
+    property string phoneNumberField: ""
     signal contactSelected(string phoneNumber)
 
 
@@ -37,7 +36,7 @@ Item {
     }
 
     function push(pattern) {
-        dialPadSearch.push(pattern);
+        dialPadSearch.push(pattern, phoneNumberField);
     }
 
     function clearAll() {
@@ -48,7 +47,7 @@ Item {
         if (contact.phoneNumbers.length > 1) {
             // try to determine the right number if user search with numbers
             for (var i=0; i < contact.phoneNumbers.length; i++) {
-                if (contact.phoneNumbers[i].startsWith(phoneNumberField.replace(/ /g,''))) {
+                if (contact.phoneNumbers[i].replace(/ /g,'').startsWith(phoneNumberField.replace(/ /g,''))) {
                     contactSelected(contact.phoneNumbers[i])
                     return
                 }
@@ -73,6 +72,7 @@ Item {
     DialPadSearch {
         id: dialPadSearch
         objectName: "dialPadSearchModel"
+        //manager: "org.nemomobile.contacts.sqlite"
         manager: "galera"
         countryCode:  PhoneUtils.getCountryCodePrefix(PhoneUtils.defaultRegion)
 
@@ -139,7 +139,6 @@ Item {
 
                 height: units.gu(6) * phoneNumbers.length
                 width: parent.width
-                Component.onCompleted: console.log(phoneNumbers)
                 delegate: ListItem {
                     divider.visible: true
                     height: layout.height + (divider.visible ? divider.height : 0)

--- a/src/qml/DialerPage/ContactDialPadSearch.qml
+++ b/src/qml/DialerPage/ContactDialPadSearch.qml
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2020 Ubports Foundation
+ *
+ * This file is part of dialer-app.
+ *
+ * dialer-app is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * dialer-app is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import QtQuick 2.0
+import Ubuntu.Components.Popups 1.3
+import Ubuntu.Components 1.3
+import Ubuntu.Telephony.PhoneNumber 0.1
+
+import dialerapp.private 0.1
+
+Item {
+    id:root
+    objectName: "root"
+    state: dialPadSearch.state
+
+    property  string phoneNumberField: ""
+    signal contactSelected(string phoneNumber)
+
+
+    function pop() {
+        dialPadSearch.pop();
+    }
+
+    function push(pattern) {
+        dialPadSearch.push(pattern);
+    }
+
+    function clearAll() {
+        dialPadSearch.clearAll()
+    }
+
+    function selectContact(contact) {
+        if (contact.phoneNumbers.length > 1) {
+            // try to determine the right number if user search with numbers
+            for (var i=0; i < contact.phoneNumbers.length; i++) {
+                if (contact.phoneNumbers[i].startsWith(phoneNumberField.replace(/ /g,''))) {
+                    contactSelected(contact.phoneNumbers[i])
+                    return
+                }
+            }
+            // otherwise, ask user to select the right number
+            var dialog = PopupUtils.open(chooseNumberDialog, fakeItemPositionner, {
+                                                           'phoneNumbers': contact.phoneNumbers
+                                                        });
+            dialog.selectedPhoneNumber.connect(
+                                        function(number) {
+                                            PopupUtils.close(dialog);
+                                            contactSelected(number)
+                                        })
+        } else {
+            // we take the first phone number from the list
+            contactSelected(contact.phoneNumbers[0])
+        }
+    }
+
+    onContactSelected: dialPadSearch.clearAll()
+
+    DialPadSearch {
+        id: dialPadSearch
+        objectName: "dialPadSearchModel"
+        manager: "galera"
+        countryCode:  PhoneUtils.getCountryCodePrefix(PhoneUtils.defaultRegion)
+
+        phoneNumber: root.phoneNumberField
+    }
+
+    ListView {
+        id: listView
+        objectName: "listView"
+        orientation: ListView.Horizontal
+        anchors.fill: parent
+        model: dialPadSearch
+        spacing: units.gu(2)
+        delegate: Rectangle {
+
+            width: lbl.width + units.gu(2)
+            height: root.height
+            color: theme.palette.normal.foreground
+            border.color: UbuntuColors.silk
+            radius: 10
+
+            Label {
+                id:lbl
+                objectName: "contactItem"
+                fontSize: "medium"
+                text:  displayLabel
+                anchors.verticalCenter: parent.verticalCenter
+                anchors.horizontalCenter: parent.horizontalCenter
+            }
+
+            MouseArea {
+                anchors.fill: parent
+                onClicked: {
+                    var contact = dialPadSearch.get(index)
+                    root.selectContact(contact)
+                }
+            }
+        }
+    }
+
+    // fake item to allow popover to position under the listView
+    Item {
+        id: fakeItemPositionner
+        objectName: "fakeItemPositionner"
+        x: parent.width /2
+        y: units.gu(12)
+    }
+
+    Component {
+        id: chooseNumberDialog
+
+        Popover {
+            id: popover
+
+            property var phoneNumbers
+            signal selectedPhoneNumber(string number)
+
+            ListView {
+                id: phoneNumberChoice
+                objectName: "phoneNumberChoice"
+
+                model: phoneNumbers
+                highlightMoveDuration : 0
+
+                height: units.gu(6) * phoneNumbers.length
+                width: parent.width
+                Component.onCompleted: console.log(phoneNumbers)
+                delegate: ListItem {
+                    divider.visible: true
+                    height: layout.height + (divider.visible ? divider.height : 0)
+                    onClicked: selectedPhoneNumber(phoneNumbers[index])
+
+                    ListItemLayout {
+                        id: layout
+                        title.text: modelData
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/qml/DialerPage/DialerPage.qml
+++ b/src/qml/DialerPage/DialerPage.qml
@@ -17,7 +17,7 @@
  */
 
 import QtContacts 5.0
-import QtQuick 2.4
+import QtQuick 2.9
 import Ubuntu.Components 1.3
 import Ubuntu.Components.Popups 1.3
 import Ubuntu.Telephony 0.1
@@ -203,8 +203,7 @@ Page {
         if (event.key == Qt.Key_Return || event.key == Qt.Key_Enter) {
             page.focus = false;
         }
-
-        keypad.keyPressed(event.key, event.text)
+        keypad.keyPressed(event.key, event.text, keypad.keyTextfromKeyCode(event.key))
     }
 
     function triggerCallAnimation() {
@@ -393,17 +392,65 @@ Page {
         Label {
             id: contactLabel
             anchors {
+                top: divider.bottom
                 horizontalCenter: divider.horizontalCenter
-                bottom: entryWithButtons.bottom
-                bottomMargin: units.gu(1)
+                topMargin: units.gu(1)
             }
             text: contactWatcher.isUnknown ? "" : contactWatcher.alias
             color: theme.palette.normal.backgroundSecondaryText
             opacity: text != "" ? 1 : 0
-            fontSize: "small"
+            fontSize: "medium"
             Behavior on opacity {
                 UbuntuNumberAnimation { }
             }
+        }
+
+        ContactDialPadSearch {
+            id: contactSearch
+            height: page.compactView ? units.gu(3): units.gu(4)
+            anchors {
+                top: divider.bottom
+                left: parent.left
+                right: parent.right
+                topMargin: units.gu(1)
+                leftMargin: units.gu(4)
+                rightMargin: units.gu(4)
+            }
+
+            phoneNumberField: input.text
+
+            onContactSelected: {
+                input.text = phoneNumber
+            }
+
+            Behavior on opacity {
+                UbuntuNumberAnimation { }
+            }
+
+            Connections {
+                target: keypad
+                enabled: mainView.settings.contactSearchWithDialPad
+                onKeyPressed : {
+                    if (keycode == Qt.Key_Backspace) {
+                        contactSearch.pop()
+                    } else {
+                        contactSearch.push(keyText)
+                    }
+                }
+                onKeyPressAndHold : {
+                    if (keycode == Qt.Key_1) {
+                        contactSearch.clearAll()
+
+                    }
+                }
+            }
+            Connections {
+                target: backspace
+                enabled: mainView.settings.contactSearchWithDialPad
+                onClicked : contactSearch.pop()
+                onPressAndHold : contactSearch.clearAll()
+            }
+
         }
 
         Keypad {
@@ -411,11 +458,13 @@ Page {
             showVoicemail: true
 
             anchors {
-                top: divider.bottom
+                top: contactSearch.bottom
                 left: parent.left
                 right: parent.right
                 bottom: parent.bottom
-                margins: units.gu(2)
+                leftMargin: units.gu(2)
+                rightMargin: units.gu(2)
+                bottomMargin: units.gu(3)
             }
             labelPixelSize: page.compactView ? units.dp(20) : units.dp(30)
             spacing: page.compactView ? 0 : 5

--- a/src/qml/DialerPage/DialerPage.qml
+++ b/src/qml/DialerPage/DialerPage.qml
@@ -416,6 +416,7 @@ Page {
                 leftMargin: units.gu(4)
                 rightMargin: units.gu(4)
             }
+            visible: contactWatcher.isUnknown
 
             phoneNumberField: input.text
 
@@ -450,7 +451,6 @@ Page {
                 onClicked : contactSearch.pop()
                 onPressAndHold : contactSearch.clearAll()
             }
-
         }
 
         Keypad {

--- a/src/qml/DialerPage/Keypad.qml
+++ b/src/qml/DialerPage/Keypad.qml
@@ -30,8 +30,19 @@ Item {
     property bool showVoicemail: false
     property alias spacing: keys.columnSpacing
 
-    signal keyPressed(int keycode, string keychar)
+    signal keyPressed(int keycode, string keychar, string keyText)
     signal keyPressAndHold(int keycode, string keychar)
+
+    function keyTextfromKeyCode(keyCode) {
+        for (var i = 0; i < keys.children.length; i++)
+        {
+            var item = keys.children[i]
+            if (item.keycode === keyCode) {
+                return item.sublabel
+            }
+        }
+        return ""
+    }
 
     GridLayout {
         id: keys
@@ -47,7 +58,7 @@ Item {
             implicitHeight: keysHeight
             label: i18n.tr("1")
             keycode: Qt.Key_1
-            onPressed: keypad.keyPressed(keycode, "1")
+            onPressed: keypad.keyPressed(keycode, "1", "1")
             onPressAndHold: keypad.keyPressAndHold(keycode, "1")
             iconSource: showVoicemail ? "voicemail" : ""
             labelFont.pixelSize: keypad.labelPixelSize
@@ -65,7 +76,7 @@ Item {
             label: i18n.tr("2")
             sublabel: i18n.tr("ABC")
             keycode: Qt.Key_2
-            onPressed: keypad.keyPressed(keycode, "2")
+            onPressed: keypad.keyPressed(keycode, "2", sublabel)
             onPressAndHold: keypad.keyPressAndHold(keycode, "2")
             labelFont.pixelSize: keypad.labelPixelSize
 
@@ -82,7 +93,7 @@ Item {
             label: i18n.tr("3")
             sublabel: i18n.tr("DEF")
             keycode: Qt.Key_3
-            onPressed: keypad.keyPressed(keycode, "3")
+            onPressed: keypad.keyPressed(keycode, "3", sublabel)
             onPressAndHold: keypad.keyPressAndHold(keycode, "3")
             labelFont.pixelSize: keypad.labelPixelSize
 
@@ -99,7 +110,7 @@ Item {
             label: i18n.tr("4")
             sublabel: i18n.tr("GHI")
             keycode: Qt.Key_4
-            onPressed: keypad.keyPressed(keycode, "4")
+            onPressed: keypad.keyPressed(keycode, "4", sublabel)
             onPressAndHold: keypad.keyPressAndHold(keycode, "4")
             labelFont.pixelSize: keypad.labelPixelSize
 
@@ -116,7 +127,7 @@ Item {
             label: i18n.tr("5")
             sublabel: i18n.tr("JKL")
             keycode: Qt.Key_5
-            onPressed: keypad.keyPressed(keycode, "5")
+            onPressed: keypad.keyPressed(keycode, "5", sublabel)
             onPressAndHold: keypad.keyPressAndHold(keycode, "5")
             labelFont.pixelSize: keypad.labelPixelSize
 
@@ -133,7 +144,7 @@ Item {
             label: i18n.tr("6")
             sublabel: i18n.tr("MNO")
             keycode: Qt.Key_6
-            onPressed: keypad.keyPressed(keycode, "6")
+            onPressed: keypad.keyPressed(keycode, "6", sublabel)
             onPressAndHold: keypad.keyPressAndHold(keycode, "6")
             labelFont.pixelSize: keypad.labelPixelSize
 
@@ -150,7 +161,7 @@ Item {
             label: i18n.tr("7")
             sublabel: i18n.tr("PQRS")
             keycode: Qt.Key_7
-            onPressed: keypad.keyPressed(keycode, "7")
+            onPressed: keypad.keyPressed(keycode, "7", sublabel)
             onPressAndHold: keypad.keyPressAndHold(keycode, "7")
             labelFont.pixelSize: keypad.labelPixelSize
 
@@ -167,7 +178,7 @@ Item {
             label: i18n.tr("8")
             sublabel: i18n.tr("TUV")
             keycode: Qt.Key_8
-            onPressed: keypad.keyPressed(keycode, "8")
+            onPressed: keypad.keyPressed(keycode, "8", sublabel)
             onPressAndHold: keypad.keyPressAndHold(keycode, "8")
             labelFont.pixelSize: keypad.labelPixelSize
 
@@ -184,7 +195,7 @@ Item {
             label: i18n.tr("9")
             sublabel: i18n.tr("WXYZ")
             keycode: Qt.Key_9
-            onPressed: keypad.keyPressed(keycode, "9")
+            onPressed: keypad.keyPressed(keycode, "9", sublabel)
             onPressAndHold: keypad.keyPressAndHold(keycode, "9")
             labelFont.pixelSize: keypad.labelPixelSize
 
@@ -202,7 +213,7 @@ Item {
             corner: Qt.BottomLeftCorner
             label: i18n.tr("*")
             keycode: Qt.Key_Asterisk
-            onPressed: keypad.keyPressed(keycode, "*")
+            onPressed: keypad.keyPressed(keycode, "*","*")
             onPressAndHold: keypad.keyPressAndHold(keycode, "*")
             labelFont.pixelSize: keypad.labelPixelSize
 
@@ -220,7 +231,7 @@ Item {
             sublabel: i18n.tr("+")
             sublabelSize: "medium"
             keycode: Qt.Key_0
-            onPressed: keypad.keyPressed(keycode, "0")
+            onPressed: keypad.keyPressed(keycode, "0", "0")
             onPressAndHold: keypad.keyPressAndHold(keycode, "0")
             labelFont.pixelSize: keypad.labelPixelSize
 
@@ -238,7 +249,7 @@ Item {
             corner: Qt.BottomRightCorner
             label: i18n.tr("#")
             keycode: Qt.Key_ssharp
-            onPressed: keypad.keyPressed(keycode, "#")
+            onPressed: keypad.keyPressed(keycode, "#", "#")
             onPressAndHold: keypad.keyPressAndHold(keycode, "#")
             labelFont.pixelSize: keypad.labelPixelSize
 

--- a/src/qml/SettingsPage/SettingsPage.qml
+++ b/src/qml/SettingsPage/SettingsPage.qml
@@ -126,6 +126,16 @@ Page {
                 enabled: (onlineAccountHelper.status === Loader.Ready) && (onlineAccountHelper.item.count > 0)
             }
 
+            ListItem.Standard {
+                control: Switch {
+                    property bool enabled: mainView.settings.contactSearchWithDialPad
+                    onEnabledChanged: checked = enabled
+                    Component.onCompleted: checked = enabled
+                    onTriggered: mainView.settings.contactSearchWithDialPad = checked
+                }
+                text: i18n.tr("Contact search with dial pad (Experimental)")
+            }
+
             Repeater {
                 model: telepathyHelper.voiceAccounts.all
 

--- a/src/qml/dialer-app.qml
+++ b/src/qml/dialer-app.qml
@@ -33,6 +33,7 @@ MainView {
     property string ussdResponseTitle: ""
     property string ussdResponseText: ""
     property alias multiplePhoneAccounts: accountsModel.multipleAccounts
+    property alias settings: generalSettings
     property QtObject account: accountsModel.defaultCallAccount
     property bool simLocked: account && account.simLocked
     property bool greeterMode: (state == "greeterMode")
@@ -149,6 +150,7 @@ MainView {
     Settings {
         id: generalSettings
         property string lastCalledPhoneNumber: ""
+        property bool contactSearchWithDialPad: true
     }
 
     PhoneUtils {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,5 +2,6 @@ execute_process(COMMAND python3 -c "from distutils.sysconfig import get_python_l
     OUTPUT_VARIABLE PYTHON_PACKAGE_DIR OUTPUT_STRIP_TRAILING_WHITESPACE)
 
 add_subdirectory(qml)
+add_subdirectory(private)
 add_subdirectory(data)
 add_subdirectory(autopilot)

--- a/tests/private/CMakeLists.txt
+++ b/tests/private/CMakeLists.txt
@@ -1,0 +1,26 @@
+find_package(Qt5Core REQUIRED)
+find_package(Qt5Qml REQUIRED)
+find_package(Qt5Quick REQUIRED)
+find_package(Qt5QuickTest REQUIRED)
+find_package(Qt5Contacts REQUIRED)
+
+set(SOURCE_DIR ${dialer-app_SOURCE_DIR}/src)
+set(SOURCES
+    ${SOURCE_DIR}/dialpadsearch.cpp
+    ${SOURCE_DIR}/contactutils.cpp
+)
+
+set(DialerAppTest_SOURCES
+    ${SOURCES}
+    DialPadSearchTest.cpp
+    )
+
+include_directories(
+    ${dialer-app_SOURCE_DIR}/src
+    ${CMAKE_CURRENT_BINARY_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+add_executable(DialPadSearchTest ${DialerAppTest_SOURCES})
+add_test(DialPadSearchTest ${CMAKE_CURRENT_BINARY_DIR}/DialPadSearchTest)
+target_link_libraries(DialPadSearchTest Qt5::Core Qt5::Contacts Qt5::Test)

--- a/tests/private/DialPadSearchTest.cpp
+++ b/tests/private/DialPadSearchTest.cpp
@@ -1,0 +1,324 @@
+/*
+ * Copyright 2020 Ubports Foundation
+ *
+ * This file is part of dialer-app.
+ *
+ * dialer-app is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * dialer-app is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <QtCore/QObject>
+#include <QtTest/QtTest>
+
+#include "dialpadsearch.h"
+#include "contactutils.h"
+#include <QContact>
+#include <QContactName>
+#include <QContactPhoneNumber>
+#include <QContactDisplayLabel>
+#include <QContactExtendedDetail>
+#include <QContactFavorite>
+
+QTCONTACTS_USE_NAMESPACE
+
+class DialPadSearchTest : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void initTestCase();
+    void init();
+    void cleanup();
+    void cleanupTestCase();
+    void testShouldSwitchToNameSearch();
+    void testShouldSwitchToNumberSearch();
+    void testShouldSwitchToNumberSearchAfterNameSearch();
+    void testShouldReturnToNoFilter();
+    void testShouldReturnToNameFilter();
+    void testShouldReturnAllContacts();
+    void testShouldFindByNumber();
+    void testShouldFindWithInternationalPrefix();
+    void testShouldReturnFavoritesFirst();
+    void testShouldClearAllWhenPhoneNumberIsOverwritten();
+
+private:
+    QContact createContact(const QString &firstName,
+                           const QString &lastName,
+                           const QStringList &phoneNumbers,
+                           const QList<int> &subTypes,
+                           const QList<int> &contexts);
+    void clearManager();
+    QContactManager *mManager;
+    DialPadSearch *dialPadSearch;
+};
+
+void DialPadSearchTest::initTestCase()
+{
+    // instanciate the shared manager using the memory backend
+    mManager = ContactUtils::sharedManager("memory");
+    dialPadSearch = new DialPadSearch();
+    dialPadSearch->setManager("memory");
+}
+
+void DialPadSearchTest::init()
+{
+    createContact("contactA",
+                  "contactA",
+                  QStringList() << "1111111111",
+                  QList<int>() << 0 << 1 << 2,
+                  QList<int>() << 3 << 4 << 5);
+
+    createContact("contactB",
+                  "contactB",
+                  QStringList() << "3333333333",
+                  QList<int>() << 0 << 1 << 2,
+                  QList<int>() << 3 << 4 << 5);
+
+}
+
+void DialPadSearchTest::cleanupTestCase()
+{
+    dialPadSearch->deleteLater();
+}
+
+void DialPadSearchTest::cleanup()
+{
+    dialPadSearch->clearAll();
+    dialPadSearch->setPhoneNumber("");
+    clearManager();
+}
+
+void DialPadSearchTest::testShouldSwitchToNameSearch()
+{
+    QSignalSpy spyRowCount(dialPadSearch, SIGNAL(rowCountChanged()));
+
+    dialPadSearch->setPhoneNumber("26");
+    dialPadSearch->push("ABC");
+    dialPadSearch->push("MNO");
+
+    QTRY_COMPARE(spyRowCount.count(), 1);
+    QCOMPARE(dialPadSearch->state(), "NAME_SEARCH");
+    QCOMPARE(dialPadSearch->rowCount(), 2);
+
+}
+
+void DialPadSearchTest::testShouldSwitchToNumberSearch()
+{
+    QSignalSpy spyRowCount(dialPadSearch, SIGNAL(rowCountChanged()));
+
+    dialPadSearch->setPhoneNumber("0");
+    dialPadSearch->push("0");
+
+    QTRY_COMPARE(spyRowCount.count(), 0);
+    QCOMPARE(dialPadSearch->state(), "NUMBER_SEARCH");
+    QCOMPARE(dialPadSearch->rowCount(), 0);
+
+}
+
+void DialPadSearchTest::testShouldReturnToNoFilter()
+{
+
+    dialPadSearch->setPhoneNumber("6");
+    dialPadSearch->push("MNO");
+    dialPadSearch->setPhoneNumber("");
+    dialPadSearch->pop();
+
+    QCOMPARE(dialPadSearch->state(), "NO_FILTER");
+    QCOMPARE(dialPadSearch->rowCount(), 0);
+
+}
+
+void DialPadSearchTest::testShouldReturnToNameFilter()
+{
+
+    QSignalSpy spyRowCount(dialPadSearch, SIGNAL(rowCountChanged()));
+
+    dialPadSearch->setPhoneNumber("26");
+    dialPadSearch->push("ABC");
+    dialPadSearch->push("MNO");
+    QTRY_COMPARE(spyRowCount.count(), 1);
+    QCOMPARE(dialPadSearch->state(), "NAME_SEARCH");
+    QCOMPARE(dialPadSearch->rowCount(), 2);
+
+    dialPadSearch->setPhoneNumber("269");
+    dialPadSearch->push("WXYZ");
+    QCOMPARE(dialPadSearch->state(), "NUMBER_SEARCH");
+    QCOMPARE(dialPadSearch->rowCount(), 0);
+
+    dialPadSearch->pop();
+
+    QCOMPARE(dialPadSearch->state(), "NAME_SEARCH");
+    QCOMPARE(dialPadSearch->rowCount(), 2);
+
+}
+
+void DialPadSearchTest::testShouldReturnAllContacts()
+{
+    QSignalSpy spyRowCount(dialPadSearch, SIGNAL(rowCountChanged()));
+
+    dialPadSearch->setPhoneNumber("26");
+    dialPadSearch->push("ABC");
+    dialPadSearch->push("MNO");
+
+    QTRY_COMPARE(spyRowCount.count(), 1);
+    QCOMPARE(dialPadSearch->state(), "NAME_SEARCH");
+    QCOMPARE(dialPadSearch->rowCount(), 2);
+
+}
+
+void DialPadSearchTest::testShouldSwitchToNumberSearchAfterNameSearch()
+{
+    QSignalSpy spyRowCount(dialPadSearch, SIGNAL(rowCountChanged()));
+
+    dialPadSearch->setPhoneNumber("666");
+    dialPadSearch->push("MNO");
+    dialPadSearch->push("MNO");
+    dialPadSearch->push("MNO");
+
+    QTRY_COMPARE(spyRowCount.count(), 1);
+    QCOMPARE(dialPadSearch->state(), "NUMBER_SEARCH");
+    QCOMPARE(dialPadSearch->rowCount(), 0);
+
+}
+
+void DialPadSearchTest::testShouldFindByNumber()
+{
+    QSignalSpy spyRowCount(dialPadSearch, SIGNAL(rowCountChanged()));
+
+    dialPadSearch->setPhoneNumber("333");
+    dialPadSearch->push("DEF");
+    dialPadSearch->push("DEF");
+    dialPadSearch->push("DEF");
+
+    QTRY_COMPARE(spyRowCount.count(), 3);
+    QCOMPARE(dialPadSearch->state(), "NUMBER_SEARCH");
+    QCOMPARE(dialPadSearch->rowCount(), 1);
+
+}
+
+void DialPadSearchTest::testShouldFindWithInternationalPrefix()
+{
+    createContact("guillaume",
+                  "guillaume",
+                  QStringList() << "+3362111445",
+                  QList<int>() << 0 << 1 << 2,
+                  QList<int>() << 3 << 4 << 5);
+
+    dialPadSearch->setCountryCode(33);
+
+    dialPadSearch->setPhoneNumber("062");
+    dialPadSearch->push("0");
+    dialPadSearch->push("MNO");
+    dialPadSearch->push("ABC");
+
+    QCOMPARE(dialPadSearch->state(), "NUMBER_SEARCH");
+    QCOMPARE(dialPadSearch->rowCount(), 1);
+}
+
+void DialPadSearchTest::testShouldReturnFavoritesFirst()
+{
+
+    QContact contact;
+
+    // Name
+    QContactName name;
+    name.setFirstName("contactZ");
+    name.setLastName("contactZ");
+    contact.saveDetail(&name);
+
+    QContactDisplayLabel displayLabel;
+    displayLabel.setLabel("favorite contact");
+    contact.saveDetail(&displayLabel);
+
+    QContactPhoneNumber number;
+    number.setNumber("5251254222");
+    number.setSubTypes(QList<int>() << 0 << 1 << 2);
+    number.setContexts(QList<int>() << 3 << 4 << 5);
+    contact.saveDetail(&number);
+
+    QContactFavorite favorite;
+    favorite.setFavorite(true);
+    contact.saveDetail(&favorite);
+
+    mManager->saveContact(&contact);
+
+
+    QSignalSpy spyRowCount(dialPadSearch, SIGNAL(rowCountChanged()));
+
+    dialPadSearch->setPhoneNumber("26");
+    dialPadSearch->push("ABC");
+    dialPadSearch->push("MNO");
+
+    QTRY_COMPARE(spyRowCount.count(), 1);
+    QCOMPARE(dialPadSearch->state(), "NAME_SEARCH");
+    QCOMPARE(dialPadSearch->rowCount(), 3);
+    QCOMPARE(dialPadSearch->get(0)["displayLabel"], "favorite contact");
+
+
+}
+
+void DialPadSearchTest::testShouldClearAllWhenPhoneNumberIsOverwritten() {
+
+    QSignalSpy spyRowCount(dialPadSearch, SIGNAL(rowCountChanged()));
+
+    dialPadSearch->setPhoneNumber("26");
+    dialPadSearch->push("ABC");
+    dialPadSearch->push("MNO");
+
+    QTRY_COMPARE(spyRowCount.count(), 1);
+    QCOMPARE(dialPadSearch->state(), "NAME_SEARCH");
+    QCOMPARE(dialPadSearch->rowCount(), 2);
+    //simulate a change from outside
+    dialPadSearch->setPhoneNumber("185");
+    QCOMPARE(dialPadSearch->state(), "NO_FILTER");
+    QCOMPARE(dialPadSearch->rowCount(), 0);
+}
+
+QContact DialPadSearchTest::createContact(const QString &firstName,
+                                           const QString &lastName,
+                                           const QStringList &phoneNumbers,
+                                           const QList<int> &subTypes,
+                                           const QList<int> &contexts)
+{
+    QContact contact;
+
+    // Name
+    QContactName name;
+    name.setFirstName(firstName);
+    name.setLastName(lastName);
+    contact.saveDetail(&name);
+
+    QContactDisplayLabel displayLabel;
+    displayLabel.setLabel(firstName + " " + lastName);
+    contact.saveDetail(&displayLabel);
+
+    Q_FOREACH(const QString &phoneNumber, phoneNumbers) {
+        QContactPhoneNumber number;
+        number.setNumber(phoneNumber);
+        number.setSubTypes(subTypes);
+        number.setContexts(contexts);
+        contact.saveDetail(&number);
+    }
+
+    mManager->saveContact(&contact);
+    return contact;
+}
+
+void DialPadSearchTest::clearManager()
+{
+    Q_FOREACH(QContact contact, mManager->contacts()) {
+        mManager->removeContact(contact.id());
+    }
+}
+
+QTEST_MAIN(DialPadSearchTest)
+#include "DialPadSearchTest.moc"

--- a/tests/private/DialPadSearchTest.cpp
+++ b/tests/private/DialPadSearchTest.cpp
@@ -100,13 +100,15 @@ void DialPadSearchTest::cleanup()
 void DialPadSearchTest::testShouldSwitchToNameSearch()
 {
     QSignalSpy spyRowCount(dialPadSearch, SIGNAL(rowCountChanged()));
+    QSignalSpy spyQueryChanged(dialPadSearch, SIGNAL(queryChanged()));
 
     dialPadSearch->setPhoneNumber("26");
     dialPadSearch->push("ABC");
     dialPadSearch->push("MNO");
 
     QTRY_COMPARE(spyRowCount.count(), 1);
-    QCOMPARE(dialPadSearch->state(), "NAME_SEARCH");
+    QTRY_COMPARE(spyQueryChanged.count(), 1);
+    QCOMPARE(dialPadSearch->state(), DialPadSearch::NAME_SEARCH);
     QCOMPARE(dialPadSearch->rowCount(), 2);
 
 }
@@ -114,12 +116,14 @@ void DialPadSearchTest::testShouldSwitchToNameSearch()
 void DialPadSearchTest::testShouldSwitchToNumberSearch()
 {
     QSignalSpy spyRowCount(dialPadSearch, SIGNAL(rowCountChanged()));
+    QSignalSpy spyQueryChanged(dialPadSearch, SIGNAL(queryChanged()));
 
     dialPadSearch->setPhoneNumber("0");
     dialPadSearch->push("0");
 
     QTRY_COMPARE(spyRowCount.count(), 0);
-    QCOMPARE(dialPadSearch->state(), "NUMBER_SEARCH");
+    QTRY_COMPARE(spyQueryChanged.count(), 0);
+    QCOMPARE(dialPadSearch->state(), DialPadSearch::NUMBER_SEARCH);
     QCOMPARE(dialPadSearch->rowCount(), 0);
 
 }
@@ -132,7 +136,7 @@ void DialPadSearchTest::testShouldReturnToNoFilter()
     dialPadSearch->setPhoneNumber("");
     dialPadSearch->pop();
 
-    QCOMPARE(dialPadSearch->state(), "NO_FILTER");
+    QCOMPARE(dialPadSearch->state(), DialPadSearch::NO_FILTER);
     QCOMPARE(dialPadSearch->rowCount(), 0);
 
 }
@@ -146,17 +150,17 @@ void DialPadSearchTest::testShouldReturnToNameFilter()
     dialPadSearch->push("ABC");
     dialPadSearch->push("MNO");
     QTRY_COMPARE(spyRowCount.count(), 1);
-    QCOMPARE(dialPadSearch->state(), "NAME_SEARCH");
+    QCOMPARE(dialPadSearch->state(), DialPadSearch::NAME_SEARCH);
     QCOMPARE(dialPadSearch->rowCount(), 2);
 
     dialPadSearch->setPhoneNumber("269");
     dialPadSearch->push("WXYZ");
-    QCOMPARE(dialPadSearch->state(), "NUMBER_SEARCH");
+    QCOMPARE(dialPadSearch->state(), DialPadSearch::NUMBER_SEARCH);
     QCOMPARE(dialPadSearch->rowCount(), 0);
 
     dialPadSearch->pop();
 
-    QCOMPARE(dialPadSearch->state(), "NAME_SEARCH");
+    QCOMPARE(dialPadSearch->state(), DialPadSearch::NAME_SEARCH);
     QCOMPARE(dialPadSearch->rowCount(), 2);
 
 }
@@ -170,7 +174,7 @@ void DialPadSearchTest::testShouldReturnAllContacts()
     dialPadSearch->push("MNO");
 
     QTRY_COMPARE(spyRowCount.count(), 1);
-    QCOMPARE(dialPadSearch->state(), "NAME_SEARCH");
+    QCOMPARE(dialPadSearch->state(), DialPadSearch::NAME_SEARCH);
     QCOMPARE(dialPadSearch->rowCount(), 2);
 
 }
@@ -184,8 +188,8 @@ void DialPadSearchTest::testShouldSwitchToNumberSearchAfterNameSearch()
     dialPadSearch->push("MNO");
     dialPadSearch->push("MNO");
 
-    QTRY_COMPARE(spyRowCount.count(), 1);
-    QCOMPARE(dialPadSearch->state(), "NUMBER_SEARCH");
+    QTRY_COMPARE(spyRowCount.count(), 3);
+    QCOMPARE(dialPadSearch->state(), DialPadSearch::NUMBER_SEARCH);
     QCOMPARE(dialPadSearch->rowCount(), 0);
 
 }
@@ -200,7 +204,7 @@ void DialPadSearchTest::testShouldFindByNumber()
     dialPadSearch->push("DEF");
 
     QTRY_COMPARE(spyRowCount.count(), 3);
-    QCOMPARE(dialPadSearch->state(), "NUMBER_SEARCH");
+    QCOMPARE(dialPadSearch->state(), DialPadSearch::NUMBER_SEARCH);
     QCOMPARE(dialPadSearch->rowCount(), 1);
 
 }
@@ -220,7 +224,7 @@ void DialPadSearchTest::testShouldFindWithInternationalPrefix()
     dialPadSearch->push("MNO");
     dialPadSearch->push("ABC");
 
-    QCOMPARE(dialPadSearch->state(), "NUMBER_SEARCH");
+    QCOMPARE(dialPadSearch->state(), DialPadSearch::NUMBER_SEARCH);
     QCOMPARE(dialPadSearch->rowCount(), 1);
 }
 
@@ -259,7 +263,7 @@ void DialPadSearchTest::testShouldReturnFavoritesFirst()
     dialPadSearch->push("MNO");
 
     QTRY_COMPARE(spyRowCount.count(), 1);
-    QCOMPARE(dialPadSearch->state(), "NAME_SEARCH");
+    QCOMPARE(dialPadSearch->state(), DialPadSearch::NAME_SEARCH);
     QCOMPARE(dialPadSearch->rowCount(), 3);
     QCOMPARE(dialPadSearch->get(0)["displayLabel"], "favorite contact");
 
@@ -275,11 +279,11 @@ void DialPadSearchTest::testShouldClearAllWhenPhoneNumberIsOverwritten() {
     dialPadSearch->push("MNO");
 
     QTRY_COMPARE(spyRowCount.count(), 1);
-    QCOMPARE(dialPadSearch->state(), "NAME_SEARCH");
+    QCOMPARE(dialPadSearch->state(), DialPadSearch::NAME_SEARCH);
     QCOMPARE(dialPadSearch->rowCount(), 2);
     //simulate a change from outside
     dialPadSearch->setPhoneNumber("185");
-    QCOMPARE(dialPadSearch->state(), "NO_FILTER");
+    QCOMPARE(dialPadSearch->state(), DialPadSearch::NO_FILTER);
     QCOMPARE(dialPadSearch->rowCount(), 0);
 }
 

--- a/tests/qml/CMakeLists.txt
+++ b/tests/qml/CMakeLists.txt
@@ -1,39 +1,61 @@
-find_program(QMLTESTRUNNER_BIN
-    NAMES qmltestrunner
-    PATHS /usr/lib/*/qt5/bin
-    NO_DEFAULT_PATH
-)
+find_package(Qt5Core REQUIRED)
+find_package(Qt5Qml REQUIRED)
+find_package(Qt5Quick REQUIRED)
+find_package(Qt5QuickTest REQUIRED)
+find_package(Qt5Contacts REQUIRED)
+
+set(TEST tst_QmlTests)
+set(XVFB_COMMAND)
 
 find_program(XVFB_RUN_BIN
     NAMES xvfb-run
 )
 
+if(XVFB_RUN_BIN)
+    set(XVFB_COMMAND ${XVFB_RUN_BIN} -s "-screen 0 1024x768x24" -a)
+else()
+    message(WARNING "Qml tests disabled: xvfb-run not found")
+endif()
+
+set(SOURCE_DIR ${dialer-app_SOURCE_DIR}/src)
+set(SOURCES
+    ${SOURCE_DIR}/dialpadsearch.cpp
+    #${SOURCE_DIR}/dialpadsearch.h
+    ${SOURCE_DIR}/contactutils.cpp
+    #${SOURCE_DIR}/contactutils.h
+)
+
+set(QmlTest_SOURCES
+    ${SOURCES}
+    tst_QmlTests.cpp
+    )
+
+include_directories(
+    ${dialer-app_SOURCE_DIR}/src
+    ${CMAKE_CURRENT_BINARY_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+#QML tests
 macro(DECLARE_QML_TEST TST_NAME TST_QML_FILE)
-    add_test(NAME ${TST_NAME}
-        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-        COMMAND ${XVFB_RUN_BIN} -a -s "-screen 0 1024x768x24" ${QMLTESTRUNNER_BIN} -v1 -o -,txt -o ${CMAKE_BINARY_DIR}/test_${TST_NAME}.xml,xunitxml -import ${qml_BINARY_DIR} -input ${CMAKE_CURRENT_SOURCE_DIR}/${TST_QML_FILE}
+    add_test(${TST_NAME} ${XVFB_COMMAND} ${CMAKE_CURRENT_BINARY_DIR}/${TEST}
+        -import ${CMAKE_BINARY_DIR}/src
+        -input ${CMAKE_CURRENT_SOURCE_DIR}/${TST_QML_FILE}
     )
 endmacro()
 
-if(QMLTESTRUNNER_BIN AND XVFB_RUN_BIN)
-    declare_qml_test("keypad_button" tst_KeypadButton.qml)
-    declare_qml_test("main_view" tst_MainView.qml)
-    declare_qml_test("stopwatch" tst_StopWatch.qml)
-    declare_qml_test("historydelegate" tst_HistoryDelegate.qml)
-    declare_qml_test("dialer_page" tst_DialerPage.qml)
-else()
-    if (NOT QMLTESTRUNNER_BIN)
-        message(WARNING "Qml tests disabled: qmltestrunner not found")
-    else()
-        message(WARNING "Qml tests disabled: xvfb-run not found")
-    endif()
-endif()
 
-set(QML_TST_FILES
-    tst_KeypadButton.qml
-    tst_StopWatch.qml
-    tst_MainView.qml
-    tst_HistoryDelegate.qml
-    tst_DialerPage.qml
-)
+add_executable(${TEST} ${QmlTest_SOURCES})
+qt5_use_modules(${TEST} Core Qml Quick QuickTest Contacts)
+
+
+declare_qml_test(KeypadButton tst_KeypadButton.qml)
+declare_qml_test(MainView tst_MainView.qml)
+declare_qml_test(StopWatch tst_StopWatch.qml)
+declare_qml_test(HistoryDelegate tst_HistoryDelegate.qml)
+declare_qml_test(DialerPage tst_DialerPage.qml)
+declare_qml_test(DialPadSearch tst_DialPadSearch.qml)
+
+# make qml files visible in QtCreator
+file(GLOB_RECURSE QML_TST_FILES *.qml)
 add_custom_target(tst_QmlFiles ALL SOURCES ${QML_TST_FILES})

--- a/tests/qml/tst_DialPadSearch.qml
+++ b/tests/qml/tst_DialPadSearch.qml
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2020 Ubports Foundation.
+ *
+ * This file is part of dialer-app.
+ *
+ * dialer-app is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * dialer-app is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import QtQuick 2.2
+import QtTest 1.0
+import QtContacts 5.0
+import Ubuntu.Test 0.1
+import '../../src/qml/DialerPage'
+
+Item {
+    id: root
+
+    width: units.gu(40)
+    height: units.gu(60)
+
+    ContactDialPadSearch {
+        id: dialPadSearch
+        width:parent.width
+    }
+
+    SignalSpy {
+        id: spyOnContactSelected
+        target: dialPadSearch
+        signalName: 'contactSelected'
+    }
+
+    TestCase {
+        id: contactsTestCase
+        when: windowShown
+
+        function cleanup() {
+            spyOnContactSelected.clear()
+            dialPadSearch.phoneNumberField = ""
+        }
+
+        function test_singlePhoneNumberSelection(){
+            var listView = findChild(dialPadSearch, 'listView')
+            waitForRendering(listView)
+            dialPadSearch.phoneNumberField = "111"
+            var contact = {displayLabel:"ContactA", phoneNumbers: ["111111111"]};
+
+            dialPadSearch.selectContact(contact)
+            spyOnContactSelected.wait()
+            compare(spyOnContactSelected.count, 1)
+            var args = spyOnContactSelected.signalArguments[0]
+            compare(args["0"], contact.phoneNumbers[0])
+
+        }
+
+        // contact number is guessed according to phoneNumberField number
+        function test_multiPhoneNumberSelectionGuessed() {
+            var listView = findChild(dialPadSearch, 'listView')
+            waitForRendering(listView)
+            dialPadSearch.phoneNumberField = "222"
+            var contact = {displayLabel:"ContactA", phoneNumbers: ["111111111", "2222222"]};
+
+            dialPadSearch.selectContact(contact)
+            spyOnContactSelected.wait()
+            compare(spyOnContactSelected.count, 1)
+
+            var args = spyOnContactSelected.signalArguments[0]
+            compare(args["0"], contact.phoneNumbers[1])
+        }
+
+        // test user interaction to select the correct number
+        function test_multiPhoneNumberSelectionPopup() {
+
+            var listView = findChild(dialPadSearch, 'listView')
+            waitForRendering(listView)
+            dialPadSearch.phoneNumberField = "Co"
+            var contact = {displayLabel:"ContactA", phoneNumbers: ["111111111", "2222222"]};
+
+            dialPadSearch.selectContact(contact)
+            wait(200) //wait popup to display
+
+            var phoneNumberChoice = findChild(root.parent, "phoneNumberChoice")
+            waitForRendering(phoneNumberChoice)
+            compare(phoneNumberChoice.count, 2)
+            verify(phoneNumberChoice.visible)
+
+            tryVerify(function(){ return phoneNumberChoice.currentItem })
+            mouseClick(phoneNumberChoice.currentItem)
+            spyOnContactSelected.wait()
+            compare(spyOnContactSelected.count, 1)
+        }
+    }
+}

--- a/tests/qml/tst_QmlTests.cpp
+++ b/tests/qml/tst_QmlTests.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Ubports Foundation
+ *
+ * Authors:
+ *  Lionel Duboeuf
+ *
+ * This file is part of messaging-app.
+ *
+ * dialer-app is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * dialer-app is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Qt
+#include <QtQuickTest/QtQuickTest>
+#include <QtQml/QtQml>
+
+// local
+#include "dialpadsearch.h"
+
+class Setup : public QObject
+{
+    Q_OBJECT
+
+public:
+    Setup() {}
+
+public Q_SLOTS:
+    void applicationAvailable() {
+        const char* uri = "dialerapp.private";
+        qmlRegisterType<DialPadSearch>(uri, 0, 1, "DialPadSearch");
+    }
+};
+
+QUICK_TEST_MAIN_WITH_SETUP(tst_QmlTests, Setup)
+#include "tst_QmlTests.moc"


### PR DESCRIPTION
fixes #98

From the idea of hendrikscheewel. We search for firstname or lastname (starting with). If no contacts found with letters then try with phone numbers. Favorites when fetched are shown first
We can disable/enable this feature in settings 

This is the continuation of previous PR: 
https://github.com/ubports/dialer-app/pull/142 and reverted by https://github.com/ubports/dialer-app/pull/152
 rewritten in c++ due to performance issues
~~https://github.com/ubports/telephony-service/pull/29 needs to be merged to have the full implementation~~

![screenshot20210331_162112761](https://user-images.githubusercontent.com/11663835/113159977-57e1ac80-923d-11eb-8016-601059b1eba3.png)
![screenshot20210331_161904799](https://user-images.githubusercontent.com/11663835/113160003-5e702400-923d-11eb-8f09-7e94c7010185.png)




Click package for test:
see https://github.com/lduboeuf/dialer-app/actions , check for last build and choose artefact

TODO:
~~contacts without phone numbers shouldn't be displayed~~