### PR TITLE
click on a contact after search populates phone number

### DIFF
--- a/src/qml/ContactViewPage/DialerContactViewPage.qml
+++ b/src/qml/ContactViewPage/DialerContactViewPage.qml
@@ -90,11 +90,7 @@ ContactViewPage {
     onContactRemoved: pageStack.pop()
     onActionTrigerred: {
         if ((action == "tel") || (action == "default")) {
-            if (callManager.hasCalls) {
-                mainView.call(detail.number, mainView.account.accountId);
-            } else {
-                mainView.startCall(detail.number)
-            }
+            mainView.populateDialpad(detail.number)
         } else {
             Qt.openUrlExternally(("%1:%2").arg(action).arg(detail.value(0)))
         }

--- a/src/qml/ContactsPage/ContactsPage.qml
+++ b/src/qml/ContactsPage/ContactsPage.qml
@@ -42,24 +42,28 @@ Page {
         }
     }
 
-    function triggerAction(contactIndex, action) {
-
-        var currentContact = contactList.listModel.contacts[contactIndex]
-        if (currentContact.phoneNumbers.length > 1) {
-            var dialog = PopupUtils.open(chooseNumberDialog, contactsPage, {
-                'contact': currentContact
-            });
-            dialog.selectedPhoneNumber.connect(
-                        function(number) {
-                            mainView.startCall(number)
-                            PopupUtils.close(dialog);
-                        })
+    function contactSelected(selectedContact) {
+        // no phone number case:
+        if (selectedContact.phoneNumbers.length === 0) {
+            mainView.viewContact(selectedContact,
+                                 contactsPage,
+                                 contactList.listModel)
         } else {
-            mainView.startCall(currentContact.phoneNumber.number)
+            // we have several phone numbers, open a popup to select to desired one
+            if (selectedContact.phoneNumbers.length > 1) {
+                var dialog = PopupUtils.open(chooseNumberDialog, contactsPage, {
+                    'contact': selectedContact
+                });
+                dialog.selectedPhoneNumber.connect(
+                            function(number) {
+                                mainView.populateDialpad(number)
+                                PopupUtils.close(dialog);
+                            })
+            } else {
+                mainView.populateDialpad(selectedContact.phoneNumber.number)
+            }
         }
     }
-
-
 
     Connections {
         target: contactList.listModel
@@ -236,17 +240,18 @@ Page {
                                            contactsPage,
                                            contactList.listModel)
             } else {
-                mainView.viewContact(contact,
-                                     contactsPage,
-                                     contactList.listModel)
+                contactSelected(contact)
             }
         }
         rightSideActions: [
                Action {
-                   iconName: "call-start"
-                   text: i18n.tr("Call")
+                   iconName: "contact"
+                   text: i18n.tr("view contact")
                    onTriggered: {
-                       triggerAction(value.contactIndex, "tel")
+                       var contact = contactList.listModel.contacts[value.contactIndex]
+                       mainView.viewContact(contact,
+                                            contactsPage,
+                                            contactList.listModel)
                    }
                }
 

--- a/src/qml/ContactsPage/ContactsPage.qml
+++ b/src/qml/ContactsPage/ContactsPage.qml
@@ -283,6 +283,7 @@ Page {
                delegate: OptionSelectorDelegate {
                    highlightWhenPressed: true
                    text: modelData.number
+                   subText: phoneTypeModel.get(phoneTypeModel.getTypeIndex(modelData)).label
                    activeFocusOnPress: false
                }
                onDelegateClicked: selectedPhoneNumber(contact.phoneNumbers[index].number)
@@ -293,6 +294,10 @@ Page {
                onPressed: PopupUtils.close(dialog)
            }
        }
+   }
+
+   ContactDetailPhoneNumberTypeModel {
+       id: phoneTypeModel
    }
 
     Component.onCompleted: {

--- a/src/qml/ContactsPage/ContactsPage.qml
+++ b/src/qml/ContactsPage/ContactsPage.qml
@@ -243,6 +243,7 @@ Page {
                 contactSelected(contact)
             }
         }
+
         rightSideActions: [
                Action {
                    iconName: "contact"
@@ -258,15 +259,11 @@ Page {
            ]
        }
 
-
    Component {
        id: chooseNumberDialog
        Dialog {
            id: dialog
            property var contact
-           title: i18n.tr("Please select a phone number")
-           modal:true
-
            signal selectedPhoneNumber(string number)
 
            ListItem.ItemSelector {
@@ -277,7 +274,7 @@ Page {
                }
                activeFocusOnPress: false
                expanded: true
-               text: i18n.tr("Numbers") + ":"
+               text: contact.displayLabel.label
                model: contact.phoneNumbers
                selectedIndex: -1
                delegate: OptionSelectorDelegate {


### PR DESCRIPTION
From the idea here: https://forums.ubports.com/topic/6054/dialer-app-search-for-contact-and-call-ux/

This will change actual behaviour of contact search and selection.
The proposed workflow is :
Search for a contact -> Contact selection populates the phone number, if several phone numbers, a popup is displayed to select one of them.
If we want to view the contact, use left swipe.

That hopefully can be a 50/50 between users that need to have the control of the number when selecting a contact and user that would like quick call
work around https://github.com/ubports/ubuntu-touch/issues/1701

Click package for test:
see https://github.com/lduboeuf/dialer-app/actions , check for last build and choose artefact