### PR TITLE
Correct theme color, main action colored

### DIFF
--- a/src/qml/Dialogs/DisableFlightModeDialog.qml
+++ b/src/qml/Dialogs/DisableFlightModeDialog.qml
@@ -30,7 +30,7 @@ Component {
         Button {
             objectName: "disableFlightModeDialogDisableButton"
             text: i18n.tr("Disable")
-            color: theme.palette.selected.focus
+            color: theme.palette.normal.focus
 
             onClicked: {
                 telepathyHelper.flightMode = false

--- a/src/qml/Dialogs/NoDefaultSIMCardDialog.qml
+++ b/src/qml/Dialogs/NoDefaultSIMCardDialog.qml
@@ -38,7 +38,7 @@ Component {
                     model: telepathyHelper.voiceAccounts.displayed
                     delegate: Label {
                         text: modelData.displayName
-                        color: theme.palette.selected.focus
+                        color: theme.palette.normal.focus
                         MouseArea {
                             anchors.fill: parent
                             onClicked: {
@@ -68,7 +68,6 @@ Component {
                 Button {
                     objectName: "noNoSimCardDefaultDialog"
                     text: i18n.tr("No")
-                    color: theme.palette.selected.focus
                     onClicked: {
                         dualSimSettings.mainViewDontAskCount = 3
                         PopupUtils.close(dialogue)
@@ -78,6 +77,7 @@ Component {
                 Button {
                     objectName: "laterNoSimCardDefaultDialog"
                     text: i18n.tr("Later")
+                    color: theme.palette.normal.focus
                     onClicked: {
                         PopupUtils.close(dialogue)
                         dualSimSettings.mainViewDontAskCount++

--- a/src/qml/Dialogs/SetDefaultSIMCardDialog.qml
+++ b/src/qml/Dialogs/SetDefaultSIMCardDialog.qml
@@ -32,7 +32,7 @@ Component {
         Button {
             objectName: "setDefaultSimCardDialogYes"
             text: i18n.tr("Change")
-            color: theme.palette.selected.focus
+            color: theme.palette.normal.focus
             onClicked: {
                 telepathyHelper.setDefaultAccount(TelepathyHelper.Voice, mainView.account)
                 PopupUtils.close(dialogue)

--- a/src/qml/Dialogs/SimLockedDialog.qml
+++ b/src/qml/Dialogs/SimLockedDialog.qml
@@ -48,7 +48,7 @@ Component {
                 Button {
                     objectName: "okSimLockedDialog"
                     text: i18n.tr("Ok")
-                    color: theme.palette.selected.focus
+                    color: theme.palette.normal.focus
                     onClicked: {
                         PopupUtils.close(dialogue)
                     }


### PR DESCRIPTION
Change `theme.palette.selected.focus` -> `theme.palette.normal.focus`
- Selected is for selected items, buttons should use normal value set
- No visual change (with current theme)

Change colored button for «Switch default SIM» Dialog

Currently:
![imatge](https://user-images.githubusercontent.com/6640041/118720814-5dfe0d80-b82a-11eb-9f5d-8a1ae2c89842.png)

With changes «Later» button should be colored, «No» button default grey