### PR TITLE
Don't preload history on app startup

### DIFF
--- a/src/qml/HistoryPage/HistoryPage.qml
+++ b/src/qml/HistoryPage/HistoryPage.qml
@@ -163,7 +163,7 @@ Page {
             sortField: "timestamp"
             sortOrder: HistorySort.DescendingOrder
         }
-        filter: emptyFilter
+        filter: bottomEdgeCommitted ? emptyFilter : null
         matchContacts: true
     }
 


### PR DESCRIPTION
This avoid unnecessary history load while bottomEdge page is not visible