### PR TITLE
ContactViewPage: do not hardcode the ContactManager name

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -18,7 +18,7 @@ Build-Depends:
  qtpim5-dev,
  qtdeclarative5-dev (>= 5.0),
  qtdeclarative5-dev-tools,
- qtdeclarative5-ubuntu-addressbook0.1,
+ qtdeclarative5-ubuntu-addressbook0.1 (>= 0.5),
  qtdeclarative5-ubuntu-history0.1,
  qtdeclarative5-ubuntu-telephony-phonenumber0.1,
  qtdeclarative5-ubuntu-telephony0.1 <!nocheck> | qtdeclarative5-ubuntu-telephony-plugin <!nocheck>,

--- a/src/contactutils.h
+++ b/src/contactutils.h
@@ -25,7 +25,7 @@ QTCONTACTS_USE_NAMESPACE
 
 namespace ContactUtils
 {
-    QContactManager *sharedManager(const QString &engine = "galera");
+    QContactManager *sharedManager(const QString &engine);
 }
 
 #endif // CONTACTUTILS_H

--- a/src/qml/ContactViewPage/DialerContactViewPage.qml
+++ b/src/qml/ContactViewPage/DialerContactViewPage.qml
@@ -115,8 +115,7 @@ ContactViewPage {
         ContactModel {
             id: contactModelHelper
 
-            manager: (typeof(QTCONTACTS_MANAGER_OVERRIDE) !== "undefined") &&
-                      (QTCONTACTS_MANAGER_OVERRIDE != "") ? QTCONTACTS_MANAGER_OVERRIDE : "galera"
+            manager: ContactManager.manager()
             autoUpdate: false
         }
     }

--- a/src/qml/DialerPage/ContactDialPadSearch.qml
+++ b/src/qml/DialerPage/ContactDialPadSearch.qml
@@ -19,6 +19,7 @@
 import QtQuick 2.0
 import Ubuntu.Components.Popups 1.3
 import Ubuntu.Components 1.3
+import Ubuntu.Contacts 0.1
 import Ubuntu.Telephony.PhoneNumber 0.1
 
 import dialerapp.private 0.1
@@ -72,8 +73,7 @@ Item {
     DialPadSearch {
         id: dialPadSearch
         objectName: "dialPadSearchModel"
-        //manager: "org.nemomobile.contacts.sqlite"
-        manager: "galera"
+        manager: ContactManager.defaultManager
         countryCode:  PhoneUtils.getCountryCodePrefix(PhoneUtils.defaultRegion)
 
         phoneNumber: root.phoneNumberField


### PR DESCRIPTION
Use whatever name is defined by the AddressBook components. This means
that if we change the backend in the AddressBook, the Dialer will
automatically use the correct backend.

Part of https://github.com/ubports/ubuntu-touch/issues/997