### PR TITLE
mark missing call as read 

### DIFF
--- a/src/qml/HistoryPage/HistoryPage.qml
+++ b/src/qml/HistoryPage/HistoryPage.qml
@@ -409,6 +409,13 @@ Page {
                         enabled: knownNumber
                     }
                 ]
+
+                Component.onCompleted: {
+                    // consider this missed call as read
+                    if (newEvent) {
+                        model.events.forEach(event => historyEventModel.markEventAsRead(event));
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Related to the emblem counter work for messaging-app and dialer-app (https://gitlab.com/ubports/core/history-service/-/merge_requests/17 )

This PR  allows to update the “unread" state of the visible missing calls when History Page is displayed.

This can be merged without the need of https://gitlab.com/ubports/core/history-service/-/merge_requests/17
