### PR TITLE
DialerContactViewPage: add phone number to the main constituent

### DIFF
--- a/src/qml/ContactViewPage/DialerContactViewPage.qml
+++ b/src/qml/ContactViewPage/DialerContactViewPage.qml
@@ -104,7 +104,7 @@ ContactViewPage {
     onContactFetched: {
         root.contact = contact
         if (root.active && root.addPhoneToContact != "") {
-            root.addPhoneToContactImpl(contact, root.addPhoneToContact)
+            root.addPhoneToContactImpl(root.contactMainConstituent, root.addPhoneToContact)
             root.addPhoneToContact = ""
         }
     }
@@ -121,8 +121,8 @@ ContactViewPage {
     }
 
     onActiveChanged: {
-        if (active && root.contact && root.addPhoneToContact != "") {
-            root.addPhoneToContactImpl(contact, root.addPhoneToContact)
+        if (active && root.contactMainConstituent && root.addPhoneToContact != "") {
+            root.addPhoneToContactImpl(root.contactMainConstituent, root.addPhoneToContact)
             root.addPhoneToContact = ""
         }
     }


### PR DESCRIPTION
DialerContactViewPage is a subclass of the ContactViewPage item from the
addressbook-app project, which has recently started to expose a
contactMainConstituent property. We need to use this contact object when
modifying the contact details, and not the aggregate contact (which is
read-only).

Fixes: https://github.com/ubports/dialer-app/issues/203